### PR TITLE
Fix parsing of special schools CSV to correctly handle commas in scho…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4958,13 +4958,29 @@ async function loadSpecialSchoolsDataFromCSV() {
         const lines = csvText.split('\n').filter(line => line.trim() !== '');
         const newData = {};
 
+        // Function to parse a CSV line, handling quoted fields
+        function parseCsvLine(line) {
+            const regex = /(?:"([^"]*)"|([^,]*))(?:,|$)/g;
+            const parts = [];
+            let match;
+            // This regex exec needs to be handled carefully in a loop.
+            // Let's reset lastIndex before each line if the regex is global.
+            regex.lastIndex = 0;
+            while ((match = regex.exec(line)) && match[0] !== '') {
+                // Use the quoted group if it exists, otherwise the unquoted group
+                parts.push(match[1] !== undefined ? match[1] : match[2]);
+            }
+            return parts;
+        }
+
         // Start from row 4 (index 3) to skip BOM, empty lines and header
         for (let i = 3; i < lines.length; i++) {
-            const parts = lines[i].split(',');
+            const parts = parseCsvLine(lines[i]);
+
             if (parts.length >= 3) {
                 // Column B (index 1) is School Name, Column C (index 2) is LGA
-                const school = parts[1].trim().replace(/"/g, '');
-                const lga = parts[2].trim().replace(/"/g, '');
+                const school = parts[1].trim();
+                const lga = parts[2].trim();
 
                 if (lga && school) {
                     if (!newData[lga]) {


### PR DESCRIPTION
…ol names.

The `loadSpecialSchoolsDataFromCSV` function was using a simple `split(',')` to parse the CSV data. This caused issues when school names contained commas.

This change replaces the simple split with a more robust CSV parsing logic that correctly handles quoted fields. This ensures that school names are parsed correctly and the dropdown is populated with the correct data.