### PR TITLE
Fix: Correct duplicate IDs causing inaccessible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1354,8 +1354,8 @@ select.form-control option {
 		 
             <!-- End of Section B placeholder -->
 
-            <h4 id="sectionCHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionCContent&#39;, &#39;sectionCHeader&#39;)">Section C: Needs Assessment ▶️</h4>
-            <div id="sectionCContent" style="display: none;">
+            <h4 id="sectionCHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionCContent_1.1', 'sectionCHeader_1.1')">Section C: Needs Assessment ▶️</h4>
+            <div id="sectionCContent_1.1" style="display: none;">
                      <p>Tick the areas where you are having difficulties in your LGEA and Schools.</p>
                 <h5>Control and Discipline</h5>
                 <table class="data-table">
@@ -1988,8 +1988,8 @@ select.form-control option {
             
             <!-- TODO: Add SILNAT form here -->
 <form id="silnatForm" class="audit-form" onsubmit="submitSilnat(event)">
-    <h4 id="sectionAHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionAContent&#39;, &#39;sectionAHeader&#39;)">SECTION A: BIO DATA 🔽</h4>
-    <div id="sectionAContent" style="display: block;">
+    <h4 id="sectionAHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionAContent_1.1', 'sectionAHeader_1.1')">SECTION A: BIO DATA 🔽</h4>
+    <div id="sectionAContent_1.1" style="display: block;">
        
             <!-- Section A: Bio Data - Conditional Part -->
             <div id="silnat_a_ht_bio_data_wrapper" class="conditional-group for-regular_school for-special_school for-home_economics_centre for-mini_resource_centre" style="display: block;">
@@ -2092,8 +2092,8 @@ select.form-control option {
 
     </div>
             <!-- Placeholder for existing fields that will become Section B -->
-            <h4 id="sectionBHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionBContent&#39;, &#39;sectionBHeader&#39;)">Section B: School/Institution Data 🔽</h4>
-            <div id="sectionBContent" style="display: block;">
+            <h4 id="sectionBHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionBContent_1.1', 'sectionBHeader_1.1')">Section B: School/Institution Data 🔽</h4>
+            <div id="sectionBContent_1.1" style="display: block;">
 			
 			 <div class="form-row full">
             <div class="form-group">
@@ -2292,8 +2292,8 @@ select.form-control option {
             </div>
             <!-- End of Section B placeholder -->
 
-            <h4 id="sectionCHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionCContent&#39;, &#39;sectionCHeader&#39;)">Section C: Needs Assessment ▶️</h4>
-            <div id="sectionCContent" style="display: none;">
+            <h4 id="sectionCHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionCContent_1.3', 'sectionCHeader_1.3')">Section C: Needs Assessment ▶️</h4>
+            <div id="sectionCContent_1.3" style="display: none;">
                      <p>Tick the areas where you are having difficulties in your LGEA and Schools.</p>
                 <h5>Control and Discipline</h5>
                 <table class="data-table">
@@ -2377,8 +2377,8 @@ select.form-control option {
                 </div>	
 						
 
-            <h4 id="sectionDHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionDContent&#39;, &#39;sectionDHeader&#39;)">Section D: School Infrastructure ▶️</h4>
-            <div id="sectionDContent" style="display: none;">
+            <h4 id="sectionDHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionDContent_1.1', 'sectionDHeader_1.1')">Section D: School Infrastructure ▶️</h4>
+            <div id="sectionDContent_1.1" style="display: none;">
                 <h4>1. INFRASTRUCTURE</h4>
                 <div class="form-group">
                     <label>Signboard</label>


### PR DESCRIPTION
- Updated the `id` attributes for collapsible sections in the SILNAT 1.1 and SILNAT 1.3 survey forms to be unique.
- Modified the `onclick` handlers to use the new unique IDs, ensuring that the `toggleSection` function can correctly target and display the content.
- This change resolves an accessibility issue where some sections of the surveys were not expandable due to JavaScript conflicts from non-unique IDs.