### PR TITLE
fix: Update MongoDB connection string to use Atlas URI

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const cors = require('cors');
 const mongoose = require('mongoose');
 
 // MongoDB Connection
-const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/audit-app';
+const MONGO_URI = process.env.MONGO_URI || 'mongodb+srv://bolatan:Ogbogbo123@cluster0.vzjwn4g.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
 
 mongoose.connect(MONGO_URI, {
   useNewUrlParser: true,


### PR DESCRIPTION
The application was configured to connect to a local MongoDB instance by default, causing a connection error when a local server was not running. I replaced the hardcoded local URI with the MongoDB Atlas connection string you provided to ensure the application connects to the correct database.