### PR TITLE
feat: Reformat LORI survey data in Excel export

### DIFF
--- a/reports.html
+++ b/reports.html
@@ -166,23 +166,96 @@
                 alert("No data to export.");
                 return;
             }
-            const worksheetData = allSurveys.map(survey => {
-                const { surveyType, createdAt, formData } = survey;
-                let flatData = {
-                    'Survey Type': surveyType,
-                    'Submission Date': new Date(createdAt).toLocaleString(),
-                };
 
-                // Simple flattening for formData
-                for (const [key, value] of Object.entries(formData)) {
-                    if (typeof value !== 'object' || value === null) {
-                        flatData[key] = value;
-                    } else {
-                        // For nested objects, just stringify them for a simple export
-                        flatData[key] = JSON.stringify(value);
+            const loriFieldMapping = {
+                "lori_b_1_a": { standard: "1. Subject content knowledge", subCategory: "a) The content is relevant" },
+                "lori_b_1_b": { standard: "1. Subject content knowledge", subCategory: "b) The content is delivered logically and sequentially" },
+                "lori_b_2_a": { standard: "2. Planning the lesson", subCategory: "a) The teacher prepared a lesson plan" },
+                "lori_b_2_b": { standard: "2. Planning the lesson", subCategory: "b) The introduction was stimulating and aroused the interest and curiosity of the learners" },
+                "lori_b_2_c": { standard: "2. Planning the lesson", subCategory: "c) The teacher referred to previous lessons and skills" },
+                "lori_b_3_a": { standard: "3. Presentation and pedagogy", subCategory: "a) Every learner is involved in learning and enjoying it" },
+                "lori_b_3_b": { standard: "3. Presentation and pedagogy", subCategory: "b) The teacher uses a variety of instructional materials to explain the concept" },
+                "lori_b_3_c": { standard: "3. Presentation and pedagogy", subCategory: "c) The learners use a variety of instructional materials to practice the concept" },
+                "lori_b_3_d": { standard: "3. Presentation and pedagogy", subCategory: "d) The learners have relevant text/workbooks" },
+                "lori_b_3_e": { standard: "3. Presentation and pedagogy", subCategory: "e) The learners have relevant writing materials such as pencils, biro, colouring pens, etc." },
+                "lori_b_3_f": { standard: "3. Presentation and pedagogy", subCategory: "f) The teacher uses /displays audio-visual materials in the class" },
+                "lori_b_3_g": { standard: "3. Presentation and pedagogy", subCategory: "g) The teacher uses various ways of grouping learners" },
+                "lori_b_3_h": { standard: "3. Presentation and pedagogy", subCategory: "h) The teacher uses language that is relevant and understandable to the learners" },
+                "lori_b_3_i": { standard: "3. Presentation and pedagogy", subCategory: "i) The teacher gives clear instructions to the learners" },
+                "lori_b_3_j": { standard: "3. Presentation and pedagogy", subCategory: "j) New words and concepts are clearly explained and related to learners’ experiences" },
+                "lori_b_4_a": { standard: "4. Relationship with learners", subCategory: "a) The teacher uses learners’ names when addressing them individually" },
+                "lori_b_4_b": { standard: "4. Relationship with learners", subCategory: "b) The teacher is fair and inclusive in their teaching and feedback" },
+                "lori_b_4_c": { standard: "4. Relationship with learners", subCategory: "c) The teacher has empathy for the learners" },
+                "lori_b_4_d": { standard: "4. Relationship with learners", subCategory: "d) The teacher responds to individual learners according to their need" },
+                "lori_b_4_e": { standard: "4. Relationship with learners", subCategory: "e) The teacher is a role model to the learners" },
+                "lori_b_5_a": { standard: "5. Class management", subCategory: "a) Every learner can see the teacher and the board" },
+                "lori_b_5_b": { standard: "5. Class management", subCategory: "b) The teacher praises and rewards the learners" },
+                "lori_b_5_c": { standard: "5. Class management", subCategory: "c) The teacher encourages good behaviour among learners" },
+                "lori_b_5_d": { standard: "5. Class management", subCategory: "d) The teacher is confident in his/her presentation" },
+                "lori_b_5_e": { standard: "5. Class management", subCategory: "e) The teacher does not use a cane, use physical force, or threatens learners" },
+                "lori_b_6_a": { standard: "6. Evaluation of learning", subCategory: "a) The lesson objectives are clearly stated at the beginning of the lesson" },
+                "lori_b_6_b": { standard: "6. Evaluation of learning", subCategory: "b) The teacher walks around the room for effective teaching and learning" },
+                "lori_b_6_c": { standard: "6. Evaluation of learning", subCategory: "c) The teacher uses a variety of assessment techniques" },
+                "lori_b_6_d": { standard: "6. Evaluation of learning", subCategory: "d) The teacher invites learners to ask questions and responds appropriately" },
+                "lori_b_6_e": { standard: "6. Evaluation of learning", subCategory: "e) The teacher checks the achievement of the lesson objectives at the end of the lesson through relevant text" },
+                "lori_b_6_f": { standard: "6. Evaluation of learning", subCategory: "f) The teacher gave relevant homework if need be" },
+                "lori_b_7":   { standard: "7. Overall Assessment", subCategory: "" },
+            };
+
+            const worksheetData = allSurveys.flatMap(survey => {
+                const { surveyType, createdAt, formData } = survey;
+
+                if (surveyType === 'lori') {
+                    const loriRows = [];
+                    const baseData = {
+                        'Survey Type': surveyType,
+                        'Submission Date': new Date(createdAt).toLocaleString(),
+                    };
+
+                    // Add all non-lori_b fields to the base data
+                    for (const [key, value] of Object.entries(formData)) {
+                        if (!key.startsWith('lori_b_')) {
+                            if (typeof value !== 'object' || value === null) {
+                                baseData[key] = value;
+                            } else {
+                                baseData[key] = JSON.stringify(value);
+                            }
+                        }
                     }
+
+                    // Create a new row for each lori_b field
+                    for (const [key, value] of Object.entries(formData)) {
+                        if (key.startsWith('lori_b_')) {
+                            const mapping = loriFieldMapping[key];
+                            if (mapping) {
+                                const newRow = {
+                                    ...baseData,
+                                    'Teacher Standard': mapping.standard,
+                                    'Sub-category': mapping.subCategory,
+                                    'Rating (1-5)': value
+                                };
+                                loriRows.push(newRow);
+                            }
+                        }
+                    }
+                    return loriRows;
+
+                } else {
+                    // Handle other survey types as before
+                    let flatData = {
+                        'Survey Type': surveyType,
+                        'Submission Date': new Date(createdAt).toLocaleString(),
+                    };
+
+                    for (const [key, value] of Object.entries(formData)) {
+                        if (typeof value !== 'object' || value === null) {
+                            flatData[key] = value;
+                        } else {
+                            flatData[key] = JSON.stringify(value);
+                        }
+                    }
+                    return [flatData];
                 }
-                return flatData;
             });
 
             const worksheet = XLSX.utils.json_to_sheet(worksheetData);


### PR DESCRIPTION
The `exportToExcel` function in `reports.html` has been updated to correctly format the LORI survey data. Previously, nested data in LORI surveys was being stringified into a single cell, making it difficult to analyze.

This change introduces a new data mapping for LORI survey fields and modifies the export logic to create a separate row for each sub-category. Each new row includes the Teacher Standard, Sub-category, and the corresponding rating (1-5), while preserving the rest of the survey data. This makes the exported data much more usable for analysis.