### PR TITLE
refactor: Remove redundant login button from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,7 +667,6 @@ select.form-control option {
                         </label>
                     </div>
                 </div>
-                <a href="/login.html" class="btn btn-secondary" style="width:auto;padding:8px 16px; margin-right: 10px; text-decoration: none;">Login</a>
                 <a href="/register.html" class="btn btn-secondary" style="width:auto;padding:8px 16px; margin-right: 10px; text-decoration: none;">Register</a>
 				<button class="btn btn-secondary" style="width:auto;padding:8px 16px;" onclick="logout()">Sign Out</button>
             </div>


### PR DESCRIPTION
This commit removes the "Login" button from the header of the `landingPage` in `index.html`. The `landingPage` is only visible to authenticated users, so the "Login" button is redundant. The "Sign Out" button is the appropriate action for a logged-in user.