### PR TITLE
Fix: Make survey sections collapsible again

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,6 @@
             margin-top: 5px;
             font-style: italic;
         }
-        }
         .credentials-info {
             background: var(--lagos-yellow);
             border: 2px solid var(--lagos-green);
@@ -623,6 +622,10 @@ select.form-control option {
     .status .btn.btn-secondary {
         display: none !important;
     }
+}
+h4[onclick] {
+    position: relative;
+    z-index: 2;
 }
         }
     </style>


### PR DESCRIPTION
The collapsible sections in the survey forms were not working because the section headers (h4 elements) were not clickable. This was likely due to being overlapped by other elements with a higher stacking order.

This change adds a CSS rule to set a `position: relative` and a `z-index` on the `h4` elements that have an `onclick` handler. This ensures that they are brought to the front and can receive click events.

This fixes the issue and makes the sections collapsible as intended.