### PR TITLE
fix: Remove duplicate toggleSection function

### DIFF
--- a/index.html
+++ b/index.html
@@ -5218,21 +5218,6 @@ function toggleSection(sectionId, headerId) {
     }
 }
 
-function toggleSection(sectionId, headerId) {
-    const section = document.getElementById(sectionId);
-    const header = document.getElementById(headerId);
-    if (section && header) {
-        const isHidden = section.style.display === 'none';
-        section.style.display = isHidden ? 'block' : 'none';
-        const headerText = header.innerText;
-        if (isHidden) {
-            header.innerText = headerText.replace('▶️', '🔽');
-        } else {
-            header.innerText = headerText.replace('🔽', '▶️');
-        }
-    }
-}
-
 // Function to handle SILNAT Institution Type change
 function handleSchoolComplexChange() {
     const schoolComplexValue = document.querySelector('input[name="school_complex"]:checked').value;


### PR DESCRIPTION
The collapsible button was not working due to a duplicate definition of the toggleSection function in index.html. This commit removes the duplicate function, which resolves the issue.