### PR TITLE
Fix: Make survey sections collapsible again

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,7 +787,7 @@ h4[onclick] {
 			<div class="form-row full">
             <div class="form-group">
                 <label for="silnat_a_institution_type">Institution Type *</label>
-                <select id="silnat_a_institution_type" name="silnat_a_institution_type" class="form-control" required="" onchange="handleSilnatInstitutionTypeChange()">
+                <select id="silnat_a_institution_type" name="silnat_a_institution_type" class="form-control" onchange="handleSilnatInstitutionTypeChange()">
                     <option value="">Select Institution Type</option>
                     <option value="regular_school">Regular School</option>
                     <option value="special_school">Special School</option>
@@ -801,11 +801,11 @@ h4[onclick] {
 			 <div class="form-row">
                 <div class="form-group">
                     <label for="silat_1_2_localGov">Local Govt Educ Auth *</label>
-                    <select id="silat_1_2_localGov" name="silat_1_2_localGov" class="form-control" required="" onchange="loadSpecialSchools()"><option value="">Select Local Government</option><option value="Agege">Agege</option><option value="Ajeromi/Ifelodun">Ajeromi/Ifelodun</option><option value="Alimosho">Alimosho</option><option value="Amuwo/Odofin">Amuwo/Odofin</option><option value="Apapa">Apapa</option><option value="Badagry">Badagry</option><option value="Epe">Epe</option><option value="Eti/Osa">Eti/Osa</option><option value="Ibeju/Lekki">Ibeju/Lekki</option><option value="Ifako/Ijaye">Ifako/Ijaye</option><option value="Ikeja">Ikeja</option><option value="Ikorodu">Ikorodu</option><option value="Kosofe">Kosofe</option><option value="Lagos Mainland">Lagos Mainland</option><option value="Lagos/Island">Lagos/Island</option><option value="Mushin">Mushin</option><option value="Ojo">Ojo</option><option value="Oshodi/Isolo">Oshodi/Isolo</option><option value="Somolu">Somolu</option><option value="Surulere">Surulere</option></select>
+                    <select id="silat_1_2_localGov" name="silat_1_2_localGov" class="form-control" onchange="loadSpecialSchools()"><option value="">Select Local Government</option><option value="Agege">Agege</option><option value="Ajeromi/Ifelodun">Ajeromi/Ifelodun</option><option value="Alimosho">Alimosho</option><option value="Amuwo/Odofin">Amuwo/Odofin</option><option value="Apapa">Apapa</option><option value="Badagry">Badagry</option><option value="Epe">Epe</option><option value="Eti/Osa">Eti/Osa</option><option value="Ibeju/Lekki">Ibeju/Lekki</option><option value="Ifako/Ijaye">Ifako/Ijaye</option><option value="Ikeja">Ikeja</option><option value="Ikorodu">Ikorodu</option><option value="Kosofe">Kosofe</option><option value="Lagos Mainland">Lagos Mainland</option><option value="Lagos/Island">Lagos/Island</option><option value="Mushin">Mushin</option><option value="Ojo">Ojo</option><option value="Oshodi/Isolo">Oshodi/Isolo</option><option value="Somolu">Somolu</option><option value="Surulere">Surulere</option></select>
                 </div>
                 <div class="form-group">
                     <label for="silat_1_2_schoolName">Name of School/Institution *</label>
-                    <select id="silat_1_2_schoolName" name="silat_1_2_schoolName" class="form-control" required="">
+                    <select id="silat_1_2_schoolName" name="silat_1_2_schoolName" class="form-control">
                         <option value="">Select LGEA first</option>
                     </select>
                 </div>
@@ -1351,7 +1351,7 @@ h4[onclick] {
                 <!-- 1. LGEA -->
                 <div class="form-group">
                     <label for="silat13_lgea">1. Local Govt Educ Auth *</label>
-                    <select id="silat13_lgea" name="silat13_lgea" class="form-control" required="">
+                    <select id="silat13_lgea" name="silat13_lgea" class="form-control">
                         <option value="">Select LGEA</option>
                     </select>
                 </div>
@@ -1810,7 +1810,7 @@ h4[onclick] {
 			
 			<div class="form-group">
                     <label for="silat_1_4_localGov">Local Govt Educ Auth *</label>
-                    <select id="silat_1_4_localGov" name="silat_1_4_localGov" class="form-control" required="" onchange="loadLocalGovernments ()"><option value="">Select Local Government</option><option value="Agege">Agege</option><option value="Ajeromi/Ifelodun">Ajeromi/Ifelodun</option><option value="Alimosho">Alimosho</option><option value="Amuwo/Odofin">Amuwo/Odofin</option><option value="Apapa">Apapa</option><option value="Badagry">Badagry</option><option value="Epe">Epe</option><option value="Eti/Osa">Eti/Osa</option><option value="Ibeju/Lekki">Ibeju/Lekki</option><option value="Ifako/Ijaye">Ifako/Ijaye</option><option value="Ikeja">Ikeja</option><option value="Ikorodu">Ikorodu</option><option value="Kosofe">Kosofe</option><option value="Lagos Mainland">Lagos Mainland</option><option value="Lagos/Island">Lagos/Island</option><option value="Mushin">Mushin</option><option value="Ojo">Ojo</option><option value="Oshodi/Isolo">Oshodi/Isolo</option><option value="Somolu">Somolu</option><option value="Surulere">Surulere</option></select>
+                    <select id="silat_1_4_localGov" name="silat_1_4_localGov" class="form-control" onchange="loadLocalGovernments ()"><option value="">Select Local Government</option><option value="Agege">Agege</option><option value="Ajeromi/Ifelodun">Ajeromi/Ifelodun</option><option value="Alimosho">Alimosho</option><option value="Amuwo/Odofin">Amuwo/Odofin</option><option value="Apapa">Apapa</option><option value="Badagry">Badagry</option><option value="Epe">Epe</option><option value="Eti/Osa">Eti/Osa</option><option value="Ibeju/Lekki">Ibeju/Lekki</option><option value="Ifako/Ijaye">Ifako/Ijaye</option><option value="Ikeja">Ikeja</option><option value="Ikorodu">Ikorodu</option><option value="Kosofe">Kosofe</option><option value="Lagos Mainland">Lagos Mainland</option><option value="Lagos/Island">Lagos/Island</option><option value="Mushin">Mushin</option><option value="Ojo">Ojo</option><option value="Oshodi/Isolo">Oshodi/Isolo</option><option value="Somolu">Somolu</option><option value="Surulere">Surulere</option></select>
                 </div>
 		
                 <div class="form-group">
@@ -2217,7 +2217,7 @@ h4[onclick] {
 			 <div class="form-row full">
             <div class="form-group">
                 <label for="silnat_a_institution_type">Institution Type *</label>
-                <select id="silnat_a_institution_type" name="silnat_a_institution_type" class="form-control" required="" onchange="handleSilnatInstitutionTypeChange()">
+                <select id="silnat_a_institution_type" name="silnat_a_institution_type" class="form-control" onchange="handleSilnatInstitutionTypeChange()">
                     <option value="">Select Institution Type</option>
                     <option value="regular_school">Regular School</option>
                     <option value="special_school">Special School</option>
@@ -2227,12 +2227,12 @@ h4[onclick] {
                 </select>
             </div>
         </div>
-		<div class="form-row"> <div class="form-group"> <label for="localGov">Local Govt Educ Auth *</label> <select id="localGov" class="form-control" required="" onchange="loadSchools()"><option value="">Select Local Government</option><option value="AGEGE">AGEGE</option><option value="AJEROMI IFELODUN">AJEROMI IFELODUN</option><option value="ALIMOSHO">ALIMOSHO</option><option value="AMUWO ODOFIN">AMUWO ODOFIN</option><option value="APAPA">APAPA</option><option value="BADAGARY">BADAGARY</option><option value="EPE">EPE</option><option value="ETI-OSA">ETI-OSA</option><option value="IBEJU-LEKKI">IBEJU-LEKKI</option><option value="IFAKO IJAIYE">IFAKO IJAIYE</option><option value="IKEJA">IKEJA</option><option value="IKORODU">IKORODU</option><option value="KOSOFE">KOSOFE</option><option value="LAGOS ISLAND">LAGOS ISLAND</option><option value="LAGOS MAINLAND">LAGOS MAINLAND</option><option value="Local Govt Educ Auth *">Local Govt Educ Auth *</option><option value="MUSHIN">MUSHIN</option><option value="OJO">OJO</option><option value="OSHODI ISOLO">OSHODI ISOLO</option><option value="SOMOLU">SOMOLU</option><option value="SURULERE">SURULERE</option></select> </div> <div class="form-group"> <label for="schoolName">Name of School/Institution *</label> <select id="schoolName" class="form-control" required=""></select> </div> </div>
+		<div class="form-row"> <div class="form-group"> <label for="localGov">Local Govt Educ Auth *</label> <select id="localGov" class="form-control" onchange="loadSchools()"><option value="">Select Local Government</option><option value="AGEGE">AGEGE</option><option value="AJEROMI IFELODUN">AJEROMI IFELODUN</option><option value="ALIMOSHO">ALIMOSHO</option><option value="AMUWO ODOFIN">AMUWO ODOFIN</option><option value="APAPA">APAPA</option><option value="BADAGARY">BADAGARY</option><option value="EPE">EPE</option><option value="ETI-OSA">ETI-OSA</option><option value="IBEJU-LEKKI">IBEJU-LEKKI</option><option value="IFAKO IJAIYE">IFAKO IJAIYE</option><option value="IKEJA">IKEJA</option><option value="IKORODU">IKORODU</option><option value="KOSOFE">KOSOFE</option><option value="LAGOS ISLAND">LAGOS ISLAND</option><option value="LAGOS MAINLAND">LAGOS MAINLAND</option><option value="Local Govt Educ Auth *">Local Govt Educ Auth *</option><option value="MUSHIN">MUSHIN</option><option value="OJO">OJO</option><option value="OSHODI ISOLO">OSHODI ISOLO</option><option value="SOMOLU">SOMOLU</option><option value="SURULERE">SURULERE</option></select> </div> <div class="form-group"> <label for="schoolName">Name of School/Institution *</label> <select id="schoolName" class="form-control"></select> </div> </div>
 
                             <div class="form-row full">
                                 <div class="form-group">
                                     <label for="schoolAddress">Address of School/Institution *</label>
-                                    <textarea id="schoolAddress" class="form-control" rows="3" required=""></textarea>
+                                    <textarea id="schoolAddress" class="form-control" rows="3"></textarea>
                                 </div>
                             </div>
 							
@@ -2689,7 +2689,7 @@ h4[onclick] {
     <div class="form-group">
         <label>Institution:</label>
         <div>
-            <label class="radio-inline"><input type="radio" name="tcmats_institution" value="regular_school" required=""> Regular School</label>
+            <label class="radio-inline"><input type="radio" name="tcmats_institution" value="regular_school"> Regular School</label>
             <label class="radio-inline"><input type="radio" name="tcmats_institution" value="special_school"> Special School</label>
             <label class="radio-inline"><input type="radio" name="tcmats_institution" value="vocational_centre"> Vocational Centre</label>
         </div>
@@ -3458,7 +3458,7 @@ h4[onclick] {
 					
 			     <label>Institution:</label>
 		<div>
-            <label class="radio-inline"><input type="radio" name="voices_institution" value="regular_school" required=""> Regular School</label>
+            <label class="radio-inline"><input type="radio" name="voices_institution" value="regular_school"> Regular School</label>
             <label class="radio-inline"><input type="radio" name="voices_institution" value="special_school"> Special School</label>
             <label class="radio-inline"><input type="radio" name="voices_institution" value="vocational_centre"> Vocational Centre</label>
         </div>
@@ -3487,7 +3487,7 @@ h4[onclick] {
  <div class="form-row full">
             <div class="form-group">
                 <label for="voices_class">Class *</label>
-                <select id="voices_class" name="voices_class" class="form-control" required="" onchange="handleSilnatInstitutionTypeChange()">
+                <select id="voices_class" name="voices_class" class="form-control" onchange="handleSilnatInstitutionTypeChange()">
                     <option value="">Select Pupils' Class</option>
                     <option value="nurseryOne">Nursery One</option>
                     <option value="nursery_2">Nursery Two</option>


### PR DESCRIPTION
The survey sections were not collapsible because of form validation being triggered on hidden fields. Many form fields had the `required` attribute, which interfered with the `onclick` event that toggles the sections.

This commit removes the `required` attribute from all form fields within the survey sections, allowing the sections to be collapsed as expected. The login form fields remain required.