### PR TITLE
Revert: Restore toggleSection function

### DIFF
--- a/index.html
+++ b/index.html
@@ -5203,6 +5203,21 @@ function updateTotal(maleId, femaleId, totalId) {
     }
 }
 
+function toggleSection(sectionId, headerId) {
+    const section = document.getElementById(sectionId);
+    const header = document.getElementById(headerId);
+    if (section && header) {
+        const isHidden = section.style.display === 'none';
+        section.style.display = isHidden ? 'block' : 'none';
+        const headerText = header.innerText;
+        if (isHidden) {
+            header.innerText = headerText.replace('▶️', '🔽');
+        } else {
+            header.innerText = headerText.replace('🔽', '▶️');
+        }
+    }
+}
+
 
 // Function to handle SILNAT Institution Type change
 function handleSchoolComplexChange() {


### PR DESCRIPTION
This reverts the accidental removal of the `toggleSection` function. The function was removed in a previous commit while attempting to remove a duplicate definition, which caused a `ReferenceError` on the page.

This commit restores the `toggleSection` function to its original state, fixing the error and ensuring the collapsible sections are functional again.