### PR TITLE
feat: Uncollapse all survey sections by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,8 +781,8 @@ h4[onclick] {
                 </div>
                 </div>
 
-            <h4 id="sectionBHeader_1.2" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionBContent_1.2&#39;, &#39;sectionBHeader_1.2&#39;)">Section B: School/Institution Data ▶️</h4>
-            <div id="sectionBContent_1.2" style="display: none;">
+            <h4 id="sectionBHeader_1.2" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionBContent_1.2', 'sectionBHeader_1.2')">Section B: School/Institution Data 🔽</h4>
+            <div id="sectionBContent_1.2" style="display: block;">
                 
 			<div class="form-row full">
             <div class="form-group">
@@ -918,8 +918,8 @@ h4[onclick] {
 		 </div>							
              
 
-            <h4 id="sectionCHeader_1.2" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionCContent_1.2&#39;, &#39;sectionCHeader_1.2&#39;)">Section C: Needs Assessment ▶️</h4>
-            <div id="sectionCContent_1.2" style="display: none;">
+            <h4 id="sectionCHeader_1.2" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionCContent_1.2', 'sectionCHeader_1.2')">Section C: Needs Assessment 🔽</h4>
+            <div id="sectionCContent_1.2" style="display: block;">
                 <p>Tick the areas where you are having difficulties in your LGEA and Schools.</p>
                <h5>Control and Discipline</h5>
                 <table class="data-table" width="100%">
@@ -1002,8 +1002,8 @@ h4[onclick] {
                 </table>
                 </div>	
 
-            <h4 id="sectionDHeader_1.2" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionDContent_1.2&#39;, &#39;sectionDHeader_1.2&#39;)">Section D: School Infrastructure ▶️</h4>
-            <div id="sectionDContent_1.2" style="display: none;">
+            <h4 id="sectionDHeader_1.2" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionDContent_1.2', 'sectionDHeader_1.2')">Section D: School Infrastructure 🔽</h4>
+            <div id="sectionDContent_1.2" style="display: block;">
                 <h4>1. INFRASTRUCTURE</h4>
                 <div class="form-group">
                     <label>Signboard</label>
@@ -1346,8 +1346,8 @@ h4[onclick] {
                 </div>
                 </div>
 
-            <h4 id="sectionBHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionBContent_1.3&#39;, &#39;sectionBHeader_1.3&#39;)">Section B: School/Institution Data ▶️</h4>
-            <div id="sectionBContent_1.3" style="display: none;">
+            <h4 id="sectionBHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionBContent_1.3', 'sectionBHeader_1.3')">Section B: School/Institution Data 🔽</h4>
+            <div id="sectionBContent_1.3" style="display: block;">
                 <!-- 1. LGEA -->
                 <div class="form-group">
                     <label for="silat13_lgea">1. Local Govt Educ Auth *</label>
@@ -1487,8 +1487,8 @@ h4[onclick] {
 		 
             <!-- End of Section B placeholder -->
 
-            <h4 id="sectionCHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionCContent_1.1&#39;, &#39;sectionCHeader_1.1&#39;)">Section C: Needs Assessment ▶️</h4>
-            <div id="sectionCContent_1.1" style="display: none;">
+            <h4 id="sectionCHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionCContent_1.3', 'sectionCHeader_1.3')">Section C: Needs Assessment 🔽</h4>
+            <div id="sectionCContent_1.3" style="display: block;">
                      <p>Tick the areas where you are having difficulties in your LGEA and Schools.</p>
                 <h5>Control and Discipline</h5>
                 <table class="data-table" width="100%">
@@ -1572,8 +1572,8 @@ h4[onclick] {
                 </div>	   
 			   
 
-            <h4 id="sectionDHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionDContent_1.3&#39;, &#39;sectionDHeader_1.3&#39;)">Section D: School Infrastructure ▶️</h4>
-            <div id="sectionDContent_1.3" style="display: none;">
+            <h4 id="sectionDHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionDContent_1.3', 'sectionDHeader_1.3')">Section D: School Infrastructure 🔽</h4>
+            <div id="sectionDContent_1.3" style="display: block;">
 			
 			 <h4>1. INFRASTRUCTURE</h4>
                 <div class="form-group">
@@ -1766,8 +1766,8 @@ h4[onclick] {
                 <u>Instruction:</u> The instrument has Four Sections. Section A requires Bio Data; Section B requires Institution Data; Section C contains items on Education Managers’ Needs Assessment while Section D is on School Infrastructure. Kindly fill in the statements that are applicable to your school.
             </div>
 
-            <h4 id="sectionAHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionAContent_1.4&#39;, &#39;sectionAHeader_1.4&#39;)">Section A: Bio Data ▶️</h4>
-            <div id="sectionAContent_1.4" style="display: none;">
+            <h4 id="sectionAHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionAContent_1.4', 'sectionAHeader_1.4')">Section A: Bio Data 🔽</h4>
+            <div id="sectionAContent_1.4" style="display: block;">
                 
                 <h5>Education Secretary Bio Data</h5>
                 <div class="form-group">
@@ -1805,8 +1805,8 @@ h4[onclick] {
                 </div>
             </div>
 
-            <h4 id="sectionBHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionBContent_1.4&#39;, &#39;sectionBHeader_1.4&#39;)">Section B: INSTITUTION DATA ▶️</h4>
-            <div id="sectionBContent_1.4" style="display: none;">
+            <h4 id="sectionBHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionBContent_1.4', 'sectionBHeader_1.4')">Section B: INSTITUTION DATA 🔽</h4>
+            <div id="sectionBContent_1.4" style="display: block;">
 			
 			<div class="form-group">
                     <label for="silat_1_4_localGov">Local Govt Educ Auth *</label>
@@ -1883,8 +1883,8 @@ h4[onclick] {
                 </div>
             </div>
 
-            <h4 id="sectionCHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionCContent_1.4&#39;, &#39;sectionCHeader_1.4&#39;)">Section C: Needs Assessment ▶️</h4>
-            <div id="sectionCContent_1.4" style="display: none;">
+            <h4 id="sectionCHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionCContent_1.4', 'sectionCHeader_1.4')">Section C: Needs Assessment 🔽</h4>
+            <div id="sectionCContent_1.4" style="display: block;">
                 <p>Tick the areas where you are having difficulties in your Local Govt Educ Auth and Schools.</p>
                 <h5>Control and Discipline</h5>
                 <table class="data-table" width="100%">
@@ -1961,8 +1961,8 @@ h4[onclick] {
                 </table>
             </div>
 
-            <h4 id="sectionDHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionDContent_1.4&#39;, &#39;sectionDHeader_1.4&#39;)">Section D: School Infrastructure ▶️</h4>
-            <div id="sectionDContent_1.4" style="display: none;">
+            <h4 id="sectionDHeader_1.4" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionDContent_1.4', 'sectionDHeader_1.4')">Section D: School Infrastructure 🔽</h4>
+            <div id="sectionDContent_1.4" style="display: block;">
                 <h5>INFRASTRUCTURE</h5>
                 <div class="form-group">
                     <label>Signboard:</label>
@@ -2411,8 +2411,8 @@ h4[onclick] {
             </div>
             <!-- End of Section B placeholder -->
 
-            <h4 id="sectionCHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionCContent_1.3&#39;, &#39;sectionCHeader_1.3&#39;)">Section C: Needs Assessment ▶️</h4>
-            <div id="sectionCContent_1.3" style="display: none;">
+            <h4 id="sectionCHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionCContent_1.1', 'sectionCHeader_1.1')">Section C: Needs Assessment 🔽</h4>
+            <div id="sectionCContent_1.1" style="display: block;">
                      <p>Tick the areas where you are having difficulties in your LGEA and Schools.</p>
                 <h5>Control and Discipline</h5>
                 <table class="data-table" width="100%">
@@ -2496,8 +2496,8 @@ h4[onclick] {
                 </div>	
 						
 
-            <h4 id="sectionDHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionDContent_1.1&#39;, &#39;sectionDHeader_1.1&#39;)">Section D: School Infrastructure ▶️</h4>
-            <div id="sectionDContent_1.1" style="display: none;">
+            <h4 id="sectionDHeader_1.1" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('sectionDContent_1.1', 'sectionDHeader_1.1')">Section D: School Infrastructure 🔽</h4>
+            <div id="sectionDContent_1.1" style="display: block;">
                 <h4>1. INFRASTRUCTURE</h4>
                 <div class="form-group">
                     <label>Signboard</label>
@@ -2683,8 +2683,8 @@ h4[onclick] {
                 <u>Instruction:</u> The instrument has Three sections; Section A, B and C. Section A requires Demographic Information and Bio Data of Teacher; Section B requires Teachers’ Needs Assessment; while Section C requires Teachers’ Subject Area Difficulties. Kindly fill in the statements that are applicable to you.
             </div>
         
-            <h3 style="cursor: pointer;" onclick="toggleSection(&#39;tcmatsSectionA&#39;, &#39;tcmatsSectionAHeader&#39;)">SECTION A: Demographic information of School and Bio Data of Teacher <span id="tcmatsSectionAHeader">▶️</span></h3>
-            <div id="tcmatsSectionA" style="display: none;">
+            <h3 style="cursor: pointer;" onclick="toggleSection('tcmatsSectionA', 'tcmatsSectionAHeader')">SECTION A: Demographic information of School and Bio Data of Teacher <span id="tcmatsSectionAHeader">🔽</span></h3>
+            <div id="tcmatsSectionA" style="display: block;">
             <div style="color:#888;margin-top:40px;"><form id="tcmatsForm" class="audit-form" onsubmit="submitSurvey(event, 'tcmats')">
     <div class="form-group">
         <label>Institution:</label>
@@ -2773,8 +2773,8 @@ h4[onclick] {
     </div>
     </form></div>
 </div>
-            <h3 style="cursor: pointer;" onclick="toggleSection(&#39;tcmatsSectionB&#39;, &#39;tcmatsSectionBHeader&#39;)">SECTION B: <span id="tcmatsSectionBHeader">▶️</span></h3>
-            <div id="tcmatsSectionB" style="display: none;">
+            <h3 style="cursor: pointer;" onclick="toggleSection('tcmatsSectionB', 'tcmatsSectionBHeader')">SECTION B: <span id="tcmatsSectionBHeader">🔽</span></h3>
+            <div id="tcmatsSectionB" style="display: block;">
                 <p>Section B contains items on Teachers’ Needs Assessment. Kindly respond by ticking (√) the appropriate box</p>
                 <p>Which of the following are you having difficulty in your job?</p>
 
@@ -2928,8 +2928,8 @@ h4[onclick] {
                     </tbody>
                 </table>
             </div>
-            <h3 style="cursor: pointer;" onclick="toggleSection(&#39;tcmatsSectionC&#39;, &#39;tcmatsSectionCHeader&#39;)">SECTION C: Subject Area Difficulties <span id="tcmatsSectionCHeader">▶️</span></h3>
-            <div id="tcmatsSectionC" style="display: none;">
+            <h3 style="cursor: pointer;" onclick="toggleSection('tcmatsSectionC', 'tcmatsSectionCHeader')">SECTION C: Subject Area Difficulties <span id="tcmatsSectionCHeader">🔽</span></h3>
+            <div id="tcmatsSectionC" style="display: block;">
                 <p>In your subject area(s), kindly identify some topics that are difficult to teach. Mention 2-5.</p>
                 <div class="form-group">
                     <label for="tcmats_difficult_topics">Difficult Topics</label>
@@ -2952,8 +2952,8 @@ h4[onclick] {
             </div>
             <!-- TODO: Add LORI form here -->
             <div style="color:#888;margin-top:40px;"><form id="loriForm" class="audit-form" onsubmit="submitSurvey(event, 'lori')">
-    <h4 id="loriSectionAHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;loriSectionAContent&#39;, &#39;loriSectionAHeader&#39;)">Section A: Demographic Data ▶️</h4>
-    <div id="loriSectionAContent" style="display: none;">
+    <h4 id="loriSectionAHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('loriSectionAContent', 'loriSectionAHeader')">Section A: Demographic Data 🔽</h4>
+    <div id="loriSectionAContent" style="display: block;">
         <table class="data-table" width="100%">
             <tbody><tr>
                 <td>LGEA</td>
@@ -3038,8 +3038,8 @@ h4[onclick] {
             </tr>
         </tbody></table>
     </div>
-    <h4 id="loriSectionBHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;loriSectionBContent&#39;, &#39;loriSectionBHeader&#39;)">Section B ▶️</h4>
-    <div id="loriSectionBContent" style="display: none;">
+    <h4 id="loriSectionBHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('loriSectionBContent', 'loriSectionBHeader')">Section B 🔽</h4>
+    <div id="loriSectionBContent" style="display: block;">
         <p>Please assess the aspect of the lesson by placing a tick in the appropriate column on the rating scale</p>
         <p>Rating Scale Descriptors 1: (poor); 2 (Fair) 3(Good); 4(Very Good); 5 (Excellent)</p>
         <table class="data-table" width="100%">
@@ -3373,8 +3373,8 @@ h4[onclick] {
             </tbody>
         </table>
     </div>
-    <h4 id="loriSectionCHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;loriSectionCContent&#39;, &#39;loriSectionCHeader&#39;)">Section C ▶️</h4>
-    <div id="loriSectionCContent" style="display: none;">
+    <h4 id="loriSectionCHeader" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection('loriSectionCContent', 'loriSectionCHeader')">Section C 🔽</h4>
+    <div id="loriSectionCContent" style="display: block;">
      
         <div class="form-group">
             <label for="lori_c_went_well_1">8. What two things went very well? (i)</label>
@@ -3452,8 +3452,8 @@ h4[onclick] {
                 <u>Instruction:</u> The instrument has Three sections; Section A, B and C. Section A requires Demographic Information and Bio Data of Teacher; Section B requires Teachers’ Needs Assessment; while Section C requires Teachers’ Subject Area Difficulties. Kindly fill in the statements that are applicable to you.
             </div>
             <form id="voicesForm" class="audit-form" onsubmit="submitSurvey(event, 'voices')">
-                <h3 style="cursor: pointer;" onclick="toggleSection(&#39;voicesSectionA&#39;, &#39;voicesSectionAHeader&#39;)">SECTION A: Demographic information of School and Bio Data of Learners <span id="voicesSectionAHeader">▶️</span></h3>
-                <div id="voicesSectionA" style="display: none;">
+                <h3 style="cursor: pointer;" onclick="toggleSection('voicesSectionA', 'voicesSectionAHeader')">SECTION A: Demographic information of School and Bio Data of Learners <span id="voicesSectionAHeader">🔽</span></h3>
+                <div id="voicesSectionA" style="display: block;">
                     <div class="form-group">
 					
 			     <label>Institution:</label>
@@ -3528,16 +3528,16 @@ h4[onclick] {
                     </div>
                 </div>
 
-                <h3 style="cursor: pointer;" onclick="toggleSection(&#39;voicesSectionB&#39;, &#39;voicesSectionBHeader&#39;)">SECTION B: Subject/Topic Difficulties <span id="voicesSectionBHeader">▶️</span></h3>
-                <div id="voicesSectionB" style="display: none;">
+                <h3 style="cursor: pointer;" onclick="toggleSection('voicesSectionB', 'voicesSectionBHeader')">SECTION B: Subject/Topic Difficulties <span id="voicesSectionBHeader">🔽</span></h3>
+                <div id="voicesSectionB" style="display: block;">
                     <div class="form-group">
                         <label>List the Subjects or Topics that you find very difficult to understand (Mention 2-5)</label>
                         <textarea name="voices_difficult_topics" class="form-control" rows="5"></textarea>
                     </div>
                 </div>
 
-                <h3 style="cursor: pointer;" onclick="toggleSection(&#39;voicesSectionC&#39;, &#39;voicesSectionCHeader&#39;)">SECTION C: Pupil’s Participation in Class <span id="voicesSectionCHeader">▶️</span></h3>
-                <div id="voicesSectionC" style="display: none;">
+                <h3 style="cursor: pointer;" onclick="toggleSection('voicesSectionC', 'voicesSectionCHeader')">SECTION C: Pupil’s Participation in Class <span id="voicesSectionCHeader">🔽</span></h3>
+                <div id="voicesSectionC" style="display: block;">
                     <p>The following questions refer to your participation during lessons. Read each question carefully and underline your answer from options 1 to 5.</p>
                     <table class="data-table" width="100%">
                         <thead>
@@ -3675,8 +3675,8 @@ h4[onclick] {
                     </table>
                 </div>
 
-                <h3 style="cursor: pointer;" onclick="toggleSection(&#39;voicesSectionD&#39;, &#39;voicesSectionDHeader&#39;)">SECTION D: School Infrastructure and Facilities <span id="voicesSectionDHeader">▶️</span></h3>
-                <div id="voicesSectionD" style="display: none;">
+                <h3 style="cursor: pointer;" onclick="toggleSection('voicesSectionD', 'voicesSectionDHeader')">SECTION D: School Infrastructure and Facilities <span id="voicesSectionDHeader">🔽</span></h3>
+                <div id="voicesSectionD" style="display: block;">
 				<p> What can you say about the following infrastructure/facilities in your School? </p>
                     <div class="form-group">
                         <label>a. School Building</label>


### PR DESCRIPTION
This change modifies `index.html` to make all collapsible sections in all surveys expanded by default.

- Changed inline style `display: none` to `display: block` for all section content divs.
- Updated the corresponding header icons from ▶️ to 🔽.
- Corrected typos in `id` attributes for some sections to ensure the toggle functionality works correctly.