### PR TITLE
Remove Average Score and Descriptor fields from LORI survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -3161,8 +3161,6 @@ h4[onclick] {
                     <td><input type="radio" name="lori_b_3_g" value="3"></td>
                     <td><input type="radio" name="lori_b_3_g" value="4"></td>
                     <td><input type="radio" name="lori_b_3_g" value="5"></td>
-                    <td><input type="text" name="lori_b_3_g_avg" class="form-control" readonly=""></td>
-                    <td><input type="text" name="lori_b_3_g_desc" class="form-control" readonly=""></td>
                 </tr>
                 <tr>
                     <td>h) The teacher uses language that is relevant and understandable to the learners</td>


### PR DESCRIPTION
- Removes the 'Average Score' and 'Descriptor' fields from the 'learners have relevant writing materials' sub-category.
- Removes the 'Average Score' and 'Descriptor' fields from the 'teacher uses various ways of grouping learners' sub-category.