### PR TITLE
feat: Make admin link visible to all, clickable only by admins

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,6 +448,24 @@
             border-radius: 2px;
             transition: 0.3s;
         }
+
+        .survey-card.disabled-card {
+            background: #f0f0f0;
+            cursor: not-allowed;
+            border-color: #dcdcdc;
+        }
+
+        .survey-card.disabled-card h2,
+        .survey-card.disabled-card p {
+            color: #b0b0b0;
+        }
+
+        .survey-card.disabled-card:hover {
+            transform: none;
+            box-shadow: 0 4px 16px rgba(30,64,175,0.08);
+            border-color: #dcdcdc;
+        }
+
         @media (max-width: 768px) {
             .hamburger {
                 display: flex;
@@ -707,7 +725,7 @@ h4[onclick] {
                     <h2>View Survey Reports</h2>
                     <p>Dashboard for all submitted data</p>
                 </div>
-                <div class="survey-card" id="admin-link" style="display: none;" onclick="window.location.href=&#39;admin.html&#39;">
+                <div class="survey-card disabled-card" id="admin-link">
                     <h2>User Administration</h2>
                     <p>Manage user accounts</p>
                 </div>
@@ -4060,19 +4078,36 @@ function toggleForceOffline() {
 function loadSession() {
     try {
         const savedUser = localStorage.getItem('auditAppCurrentUser');
+        const adminLink = document.getElementById('admin-link');
+
         if (savedUser) {
             const user = JSON.parse(savedUser);
             currentUser = user.username;
             document.getElementById('authScreen').classList.add('hidden');
             document.getElementById('landingPage').classList.remove('hidden');
             document.getElementById('mainApp').classList.add('hidden');
+
             if (user.role === 'admin') {
-                document.getElementById('admin-link').style.display = 'block';
+                adminLink.classList.remove('disabled-card');
+                adminLink.onclick = () => { window.location.href = 'admin.html'; };
+            } else {
+                adminLink.classList.add('disabled-card');
+                adminLink.onclick = null;
             }
             console.log('Session restored for user:', currentUser);
+        } else {
+            // If no user is logged in, ensure the card is disabled.
+            adminLink.classList.add('disabled-card');
+            adminLink.onclick = null;
         }
     } catch (e) {
         console.error('Error loading session:', e);
+        // In case of error, also ensure it's disabled
+        const adminLink = document.getElementById('admin-link');
+        if(adminLink) {
+            adminLink.classList.add('disabled-card');
+            adminLink.onclick = null;
+        }
     }
 }
 
@@ -4098,9 +4133,16 @@ async function login() {
             document.getElementById('authScreen').classList.add('hidden');
             document.getElementById('landingPage').classList.remove('hidden');
             document.getElementById('mainApp').classList.add('hidden');
+
+            const adminLink = document.getElementById('admin-link');
             if (data.role === 'admin') {
-                document.getElementById('admin-link').style.display = 'block';
+                adminLink.classList.remove('disabled-card');
+                adminLink.onclick = () => { window.location.href = 'admin.html'; };
+            } else {
+                adminLink.classList.add('disabled-card');
+                adminLink.onclick = null;
             }
+
             loadData();
             loadLocalGovernments();
             updateDashboard();


### PR DESCRIPTION
This change implements the new requirement for the User Administration module link. Previously, the link was hidden from non-admin users. Now, the link is always visible on the welcome page but is styled as a disabled, unclickable card for non-admin users. When an admin user logs in, the card becomes enabled and clickable.

Changes include:
- Added a 'disabled-card' CSS class to `index.html` to visually disable the admin link.
- Modified the admin link HTML to be visible by default with the disabled class.
- Updated the `login()` and `loadSession()` JavaScript functions in `index.html` to dynamically add or remove the 'disabled-card' class and the `onclick` handler based on the logged-in user's role.