### PR TITLE
feat: Generalize admin creation script

### DIFF
--- a/createAdmin.js
+++ b/createAdmin.js
@@ -3,40 +3,47 @@ const User = require('./models/User');
 
 const MONGO_URI = process.env.MONGO_URI || 'mongodb+srv://bolatan:Ogbogbo123@cluster0.vzjwn4g.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
 
-const ensureAdminUser = async () => {
+const createAdminUser = async (username, password) => {
   try {
-    let adminUser = await User.findOne({ username: 'admin' });
+    let user = await User.findOne({ username });
 
-    if (adminUser) {
-        console.log('Admin user already exists.');
-        // Optional: Update role or password if needed for consistency
-        if (adminUser.role !== 'admin') {
-            adminUser.role = 'admin';
-            await adminUser.save();
-            console.log('Admin user role updated to "admin".');
+    if (user) {
+        console.log(`User '${username}' already exists.`);
+        if (user.role !== 'admin') {
+            user.role = 'admin';
+            await user.save();
+            console.log(`User '${username}' role updated to "admin".`);
         }
     } else {
-      // Create admin user if it doesn't exist
       await User.create({
-        username: 'admin',
-        password: 'password123',
+        username,
+        password,
         role: 'admin',
       });
-      console.log('Admin user created successfully.');
+      console.log(`Admin user '${username}' created successfully.`);
     }
   } catch (error) {
-    console.error('Error ensuring admin user:', error);
+    console.error(`Error creating admin user '${username}':`, error);
   }
 };
 
 const run = async () => {
+  const username = process.argv[2];
+  const password = process.argv[3];
+
+  if (!username || !password) {
+    console.log('Please provide a username and password.');
+    console.log('Usage: node createAdmin.js <username> <password>');
+    return;
+  }
+
   try {
     await mongoose.connect(MONGO_URI, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
     console.log('Successfully connected to MongoDB');
-    await ensureAdminUser();
+    await createAdminUser(username, password);
   } catch (err) {
     console.error('Failed to connect to MongoDB', err);
   } finally {


### PR DESCRIPTION
The `createAdmin.js` script has been updated to accept a username and password as command-line arguments. This makes the script more flexible and allows for the creation of multiple admin users with different credentials, rather than being hardcoded to a single 'admin' user.