### PR TITLE
Fix: Remove redirect after survey submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -5262,10 +5262,6 @@ async function submitSurvey(event, surveyType) {
                 // Also clear file previews if any
                 const uploadedFilesDiv = form.querySelector('.uploaded-files');
                 if (uploadedFilesDiv) uploadedFilesDiv.innerHTML = '';
-
-                setTimeout(() => {
-                    backToLanding();
-                }, 2000);
             } else {
                 const err = await res.json();
                 feedback.style.color = 'var(--lagos-red)';

--- a/index1.html
+++ b/index1.html
@@ -5700,9 +5700,6 @@ async function submitSilnat(event) {
             feedback.textContent = 'SILNAT survey submitted successfully!';
             form.reset();
             document.getElementById('silnat_uploadedFiles').innerHTML = '';
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';
@@ -5737,9 +5734,6 @@ async function submitSilat1_2(event) {
             feedback.style.color = 'var(--lagos-green)';
             feedback.textContent = 'SILNAT 1.2 survey submitted successfully!';
             form.reset();
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';
@@ -5774,9 +5768,6 @@ async function submitSilat1_3(event) {
             feedback.style.color = 'var(--lagos-green)';
             feedback.textContent = 'SILNAT 1.3 survey submitted successfully!';
             form.reset();
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';
@@ -5811,9 +5802,6 @@ async function submitSilat1_4(event) {
             feedback.style.color = 'var(--lagos-green)';
             feedback.textContent = 'SILNAT 1.4 survey submitted successfully!';
             form.reset();
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';
@@ -5860,9 +5848,6 @@ async function submitTcmats(event) {
             feedback.textContent = 'TCMATS survey submitted successfully!';
             form.reset();
             document.getElementById('tcmats_uploadedFiles').innerHTML = '';
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';
@@ -5910,9 +5895,6 @@ async function submitLori(event) {
             feedback.textContent = 'LORI survey submitted successfully!';
             form.reset();
             document.getElementById('lori_uploadedFiles').innerHTML = '';
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';
@@ -5959,9 +5941,6 @@ async function submitVoices(event) {
             feedback.textContent = 'VOICES survey submitted successfully!';
             form.reset();
             document.getElementById('voices_uploadedFiles').innerHTML = '';
-            setTimeout(() => {
-                backToLanding();
-            }, 2000);
         } else {
             const err = await res.json();
             feedback.style.color = 'var(--lagos-red)';


### PR DESCRIPTION
I have removed the JavaScript code that was incorrectly redirecting you to the welcome page after a successful survey submission.

The erroneous redirection was present in both `index.html` and `index1.html`. I have removed the code from the success handlers of all survey submission functions (`submitSilnat`, `submitSilat1_2`, `submitSilat1_3`, `submitSilat1_4`, `submitTcmats`, `submitLori`, `submitVoices`).

After this change, the application will now remain on the survey page and display a success message upon submission, which is the correct behavior.