### PR TITLE
Fix: Prevent login page flicker on welcome screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@ h4[onclick] {
   		
 		  <div class="container">
         <!-- Authentication Screen -->
-        <div id="authScreen" class="auth-container">
+        <div id="authScreen" class="auth-container hidden">
             <h3 class="auth-title">LSUBEB/PIMU NEEDS INSTRUMENT Login</h3>
             
             


### PR DESCRIPTION
The login page was briefly displayed to authenticated users before redirecting to the welcome page. This was because the login screen was visible by default and was only hidden after a script checked for authentication on page load.

This fix adds the `hidden` class to the login screen's container by default. The existing JavaScript will then correctly display either the login screen or the welcome page after checking authentication status, without the initial flicker.