### PR TITLE
Fix multiple bugs in Form 1.1 (SILNAT 1.1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -954,79 +954,79 @@ h4[onclick] {
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.2"></td><td><input type="radio" name="discipline_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.2"></td><td><input type="radio" name="discipline_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.2"></td><td><input type="radio" name="discipline_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.2"></td><td><input type="radio" name="discipline_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.2"></td><td><input type="radio" name="discipline_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.1" value="yes"></td><td><input type="radio" name="discipline_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.1" value="yes"></td><td><input type="radio" name="discipline_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.1" value="yes"></td><td><input type="radio" name="discipline_c_1.1" value="no"></td></tr>
+                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.1" value="yes"></td><td><input type="radio" name="discipline_d_1.1" value="no"></td></tr>
+                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.1" value="yes"></td><td><input type="radio" name="discipline_e_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 <h5>Cooperation and Team Work</h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.2"></td><td><input type="radio" name="cooperation_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.2"></td><td><input type="radio" name="cooperation_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.2"></td><td><input type="radio" name="cooperation_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.2"></td><td><input type="radio" name="cooperation_d_1.2"></td></tr>
+                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.1" value="yes"></td><td><input type="radio" name="cooperation_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.1" value="yes"></td><td><input type="radio" name="cooperation_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.1" value="yes"></td><td><input type="radio" name="cooperation_c_1.1" value="no"></td></tr>
+                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.1" value="yes"></td><td><input type="radio" name="cooperation_d_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 <h5>Communication in the School</h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.2"></td><td><input type="radio" name="communication_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.2"></td><td><input type="radio" name="communication_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.2"></td><td><input type="radio" name="communication_c_1.2"></td></tr>
+                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.1" value="yes"></td><td><input type="radio" name="communication_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.1" value="yes"></td><td><input type="radio" name="communication_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.1" value="yes"></td><td><input type="radio" name="communication_c_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 <h5>School and Community Relations</h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.2"></td><td><input type="radio" name="community_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.2"></td><td><input type="radio" name="community_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.2"></td><td><input type="radio" name="community_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.2"></td><td><input type="radio" name="community_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.2"></td><td><input type="radio" name="community_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.1" value="yes"></td><td><input type="radio" name="community_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.1" value="yes"></td><td><input type="radio" name="community_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.1" value="yes"></td><td><input type="radio" name="community_c_1.1" value="no"></td></tr>
+                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.1" value="yes"></td><td><input type="radio" name="community_d_1.1" value="no"></td></tr>
+                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.1" value="yes"></td><td><input type="radio" name="community_e_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 <h5>Supervision and Monitoring</h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.2"></td><td><input type="radio" name="supervision_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.2"></td><td><input type="radio" name="supervision_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.2"></td><td><input type="radio" name="supervision_c_1.2"></td></tr>
-						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_c_1.2"></td><td><input type="radio" name="supervision_c_1.2"></td></tr>
-                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_d_1.2"></td><td><input type="radio" name="supervision_d_1.2"></td></tr>
+                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.1" value="yes"></td><td><input type="radio" name="supervision_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.1" value="yes"></td><td><input type="radio" name="supervision_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.1" value="yes"></td><td><input type="radio" name="supervision_c_1.1" value="no"></td></tr>
+						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_d_1.1" value="yes"></td><td><input type="radio" name="supervision_d_1.1" value="no"></td></tr>
+                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_e_1.1" value="yes"></td><td><input type="radio" name="supervision_e_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 <h5>School Records</h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.2"></td><td><input type="radio" name="records_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Maintenance of daily classrom register by teachers</td><td><input type="radio" name="records_b_1.2"></td><td><input type="radio" name="records_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.2"></td><td><input type="radio" name="records_c_1.2"></td></tr>
-						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_c_1.2"></td><td><input type="radio" name="records_c_1.2"></td></tr>
-                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_e_1.2"></td><td><input type="radio" name="records_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.1" value="yes"></td><td><input type="radio" name="records_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Maintenance of daily classrom register by teachers</td><td><input type="radio" name="records_b_1.1" value="yes"></td><td><input type="radio" name="records_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.1" value="yes"></td><td><input type="radio" name="records_c_1.1" value="no"></td></tr>
+						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_d_1.1" value="yes"></td><td><input type="radio" name="records_d_1.1" value="no"></td></tr>
+                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_e_1.1" value="yes"></td><td><input type="radio" name="records_e_1.1" value="no"></td></tr>
+						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_f_1.1" value="yes"></td><td><input type="radio" name="records_f_1.1" value="no"></td></tr>
+						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_g_1.1" value="yes"></td><td><input type="radio" name="records_g_1.1" value="no"></td></tr>
+						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_h_1.1" value="yes"></td><td><input type="radio" name="records_h_1.1" value="no"></td></tr>
+                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_i_1.1" value="yes"></td><td><input type="radio" name="records_i_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 <h5>Health and Hygiene</h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.2"></td><td><input type="radio" name="health_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.2"></td><td><input type="radio" name="health_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.2"></td><td><input type="radio" name="health_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.2"></td><td><input type="radio" name="health_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.2"></td><td><input type="radio" name="health_e_1.2"></td></tr>
-						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_e_1.2"></td><td><input type="radio" name="health_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.1" value="yes"></td><td><input type="radio" name="health_a_1.1" value="no"></td></tr>
+                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.1" value="yes"></td><td><input type="radio" name="health_b_1.1" value="no"></td></tr>
+                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.1" value="yes"></td><td><input type="radio" name="health_c_1.1" value="no"></td></tr>
+                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.1" value="yes"></td><td><input type="radio" name="health_d_1.1" value="no"></td></tr>
+                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.1" value="yes"></td><td><input type="radio" name="health_e_1.1" value="no"></td></tr>
+						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_f_1.1" value="yes"></td><td><input type="radio" name="health_f_1.1" value="no"></td></tr>
                     </tbody>
                 </table>
                 </div>	
@@ -2314,11 +2314,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_teachers_male">Male</label>
-                        <input type="number" id="silnat_teachers_male" name="silnat_teachers_male" class="form-control" min="0" placeholder="Male">
+                        <input type="number" id="silnat_teachers_male" name="silnat_teachers_male" class="form-control" min="0" placeholder="Male" oninput="updateSilnatTotalTeachers()">
                     </div>
                     <div class="form-group">
                         <label for="silnat_teachers_female">Female</label>
-                        <input type="number" id="silnat_teachers_female" name="silnat_teachers_female" class="form-control" min="0" placeholder="Female">
+                        <input type="number" id="silnat_teachers_female" name="silnat_teachers_female" class="form-control" min="0" placeholder="Female" oninput="updateSilnatTotalTeachers()">
                     </div>
                     <div class="form-group">
                         <label for="silnat_teachers_total">Total</label>
@@ -2332,11 +2332,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_non_teaching_male">Male</label>
-                        <input type="number" id="silnat_non_teaching_male" name="silnat_non_teaching_male" class="form-control" min="0" placeholder="Male">
+                        <input type="number" id="silnat_non_teaching_male" name="silnat_non_teaching_male" class="form-control" min="0" placeholder="Male" oninput="updateSilnatTotalNonTeachingStaff()">
                     </div>
                     <div class="form-group">
                         <label for="silnat_non_teaching_female">Female</label>
-                        <input type="number" id="silnat_non_teaching_female" name="silnat_non_teaching_female" class="form-control" min="0" placeholder="Female">
+                        <input type="number" id="silnat_non_teaching_female" name="silnat_non_teaching_female" class="form-control" min="0" placeholder="Female" oninput="updateSilnatTotalNonTeachingStaff()">
                     </div>
                     <div class="form-group">
                         <label for="silnat_non_teaching_total">Total</label>
@@ -2352,11 +2352,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_eccde_male">Male</label>
-                        <input type="number" id="silnat_pupils_eccde_male" name="silnat_pupils_eccde_male" class="form-control" min="0" placeholder="Male">
+                        <input type="number" id="silnat_pupils_eccde_male" name="silnat_pupils_eccde_male" class="form-control" min="0" placeholder="Male" oninput="updateSilnatTotalPupilsEccde(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_eccde_female">Female</label>
-                        <input type="number" id="silnat_pupils_eccde_female" name="silnat_pupils_eccde_female" class="form-control" min="0" placeholder="Female">
+                        <input type="number" id="silnat_pupils_eccde_female" name="silnat_pupils_eccde_female" class="form-control" min="0" placeholder="Female" oninput="updateSilnatTotalPupilsEccde(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_eccde_total">Total</label>
@@ -2370,11 +2370,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_primary_male">Male</label>
-                        <input type="number" id="silnat_pupils_primary_male" name="silnat_pupils_primary_male" class="form-control" min="0" placeholder="Male">
+                        <input type="number" id="silnat_pupils_primary_male" name="silnat_pupils_primary_male" class="form-control" min="0" placeholder="Male" oninput="updateSilnatTotalPupilsPrimary(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_primary_female">Female</label>
-                        <input type="number" id="silnat_pupils_primary_female" name="silnat_pupils_primary_female" class="form-control" min="0" placeholder="Female">
+                        <input type="number" id="silnat_pupils_primary_female" name="silnat_pupils_primary_female" class="form-control" min="0" placeholder="Female" oninput="updateSilnatTotalPupilsPrimary(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_primary_total">Total</label>
@@ -2388,11 +2388,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_special_male">Male</label>
-                        <input type="number" id="silnat_pupils_special_male" name="silnat_pupils_special_male" class="form-control" min="0" placeholder="Male">
+                        <input type="number" id="silnat_pupils_special_male" name="silnat_pupils_special_male" class="form-control" min="0" placeholder="Male" oninput="updateSilnatTotalPupilsSpecial(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_special_female">Female</label>
-                        <input type="number" id="silnat_pupils_special_female" name="silnat_pupils_special_female" class="form-control" min="0" placeholder="Female">
+                        <input type="number" id="silnat_pupils_special_female" name="silnat_pupils_special_female" class="form-control" min="0" placeholder="Female" oninput="updateSilnatTotalPupilsSpecial(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_special_total">Total</label>
@@ -2402,15 +2402,15 @@ h4[onclick] {
             </div>
 			
 			 <div class="form-group" style="margin-top: 20px;">
-                <label style="font-weight: bold; display: block; margin-bottom: 10px;">Number of Pupils in the School:</label>
+                <label style="font-weight: bold; display: block; margin-bottom: 10px;">Total Number of Pupils in the School (Auto-Calculated):</label>
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_male">Male</label>
-                        <input type="number" id="silnat_pupils_male" name="silnat_pupils_male" class="form-control" min="0" placeholder="Male">
+                        <input type="number" id="silnat_pupils_male" name="silnat_pupils_male" class="form-control" min="0" placeholder="Male" readonly style="background-color: var(--lagos-blue) !important; opacity: 0.8 !important; color: var(--lagos-white) !important;">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_female">Female</label>
-                        <input type="number" id="silnat_pupils_female" name="silnat_pupils_female" class="form-control" min="0" placeholder="Female">
+                        <input type="number" id="silnat_pupils_female" name="silnat_pupils_female" class="form-control" min="0" placeholder="Female" readonly style="background-color: var(--lagos-blue) !important; opacity: 0.8 !important; color: var(--lagos-white) !important;">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_total">Total</label>
@@ -2420,11 +2420,8 @@ h4[onclick] {
             </div>
 
             <div class="form-group" style="margin-top: 20px;">
-                <label for="silnat_teacher_pupil_ratio">Teacher/Pupils Ratio:</label>
-                <div style="display: flex; align-items: center;">
-                    <input type="number" id="silnat_teacher_pupil_ratio" name="silnat_teacher_pupil_ratio" class="form-control" min="0" step="any" placeholder="Enter ratio value" style="flex-grow: 1;">
-                    <span style="margin-left: 8px; font-size: 1em; flex-shrink: 0;">%</span>
-                </div>
+                <label for="silnat_teacher_pupil_ratio">Teacher/Pupils Ratio (Auto-Calculated):</label>
+                <input type="text" id="silnat_teacher_pupil_ratio" name="silnat_teacher_pupil_ratio" class="form-control" placeholder="1 : X" readonly style="background-color: var(--lagos-blue) !important; opacity: 0.8 !important; color: var(--lagos-white) !important;">
             </div>
 
             <div class="form-group" style="margin-top: 20px;">
@@ -5347,21 +5344,6 @@ function toggleSection(sectionId, headerId) {
     }
 }
 
-// Function to handle SILNAT Institution Type change
-function toggleSection(sectionId, headerId) {
-    const section = document.getElementById(sectionId);
-    const header = document.getElementById(headerId);
-    if (section && header) {
-        const isHidden = section.style.display === 'none';
-        section.style.display = isHidden ? 'block' : 'none';
-        const headerText = header.innerText;
-        if (isHidden) {
-            header.innerText = headerText.replace('▶️', '🔽');
-        } else {
-            header.innerText = headerText.replace('🔽', '▶️');
-        }
-    }
-}
 
 function handleSchoolComplexChange() {
     const schoolComplexValue = document.querySelector('input[name="school_complex"]:checked').value;
@@ -5530,58 +5512,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Event listeners for SILNAT teacher count auto-calculation
-    const maleTeachersInput = document.getElementById('silnat_teachers_male');
-    const femaleTeachersInput = document.getElementById('silnat_teachers_female');
-
-    if (maleTeachersInput) {
-        maleTeachersInput.addEventListener('input', updateSilnatTotalTeachers);
-    }
-    if (femaleTeachersInput) {
-        femaleTeachersInput.addEventListener('input', updateSilnatTotalTeachers);
-    }
-    // Initialize total teachers count in case of pre-filled values (e.g. form edit)
-    // updateSilnatTotalTeachers(); // Call if needed on form load/edit
-
-    // Event listeners for SILNAT non-teaching staff count auto-calculation
-    const maleNonTeachingInput = document.getElementById('silnat_non_teaching_male');
-    const femaleNonTeachingInput = document.getElementById('silnat_non_teaching_female');
-
-    if (maleNonTeachingInput) {
-        maleNonTeachingInput.addEventListener('input', updateSilnatTotalNonTeachingStaff);
-    }
-    if (femaleNonTeachingInput) {
-        femaleNonTeachingInput.addEventListener('input', updateSilnatTotalNonTeachingStaff);
-    }
-
-    // Event listeners for SILNAT pupil count auto-calculation
-    const malePupilsInput = document.getElementById('silnat_pupils_male');
-    const femalePupilsInput = document.getElementById('silnat_pupils_female');
-
-    if (malePupilsInput) {
-        malePupilsInput.addEventListener('input', updateSilnatTotalPupils);
-    }
-    if (femalePupilsInput) {
-        femalePupilsInput.addEventListener('input', updateSilnatTotalPupils);
-    }
-
-    // Event listeners for SILNAT ECCDE pupil count auto-calculation
-    const malePupilsEccdeInput = document.getElementById('silnat_pupils_eccde_male');
-    const femalePupilsEccdeInput = document.getElementById('silnat_pupils_eccde_female');
-    if (malePupilsEccdeInput) { malePupilsEccdeInput.addEventListener('input', updateSilnatTotalPupilsEccde); }
-    if (femalePupilsEccdeInput) { femalePupilsEccdeInput.addEventListener('input', updateSilnatTotalPupilsEccde); }
-
-    // Event listeners for SILNAT Primary pupil count auto-calculation
-    const malePupilsPrimaryInput = document.getElementById('silnat_pupils_primary_male');
-    const femalePupilsPrimaryInput = document.getElementById('silnat_pupils_primary_female');
-    if (malePupilsPrimaryInput) { malePupilsPrimaryInput.addEventListener('input', updateSilnatTotalPupilsPrimary); }
-    if (femalePupilsPrimaryInput) { femalePupilsPrimaryInput.addEventListener('input', updateSilnatTotalPupilsPrimary); }
-
-    // Event listeners for SILNAT Special Learners pupil count auto-calculation
-    const malePupilsSpecialInput = document.getElementById('silnat_pupils_special_male');
-    const femalePupilsSpecialInput = document.getElementById('silnat_pupils_special_female');
-    if (malePupilsSpecialInput) { malePupilsSpecialInput.addEventListener('input', updateSilnatTotalPupilsSpecial); }
-    if (femalePupilsSpecialInput) { femalePupilsSpecialInput.addEventListener('input', updateSilnatTotalPupilsSpecial); }
+    // Event listeners for total calculations are now inline in the HTML (oninput="...")
 
     // SILAT 1.4 totals
     setupTotalCalculation('staff_male_1.4', 'staff_female_1.4', 'staff_total_1.4');
@@ -5596,6 +5527,45 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Function to update total teachers for SILNAT form
+function updateGrandTotalPupils() {
+    // Male pupils
+    const eccdeMale = parseInt(document.getElementById('silnat_pupils_eccde_male').value, 10) || 0;
+    const primaryMale = parseInt(document.getElementById('silnat_pupils_primary_male').value, 10) || 0;
+    const specialMale = parseInt(document.getElementById('silnat_pupils_special_male').value, 10) || 0;
+    const totalMalePupilsInput = document.getElementById('silnat_pupils_male');
+    if (totalMalePupilsInput) {
+        totalMalePupilsInput.value = eccdeMale + primaryMale + specialMale;
+    }
+
+    // Female pupils
+    const eccdeFemale = parseInt(document.getElementById('silnat_pupils_eccde_female').value, 10) || 0;
+    const primaryFemale = parseInt(document.getElementById('silnat_pupils_primary_female').value, 10) || 0;
+    const specialFemale = parseInt(document.getElementById('silnat_pupils_special_female').value, 10) || 0;
+    const totalFemalePupilsInput = document.getElementById('silnat_pupils_female');
+    if (totalFemalePupilsInput) {
+        totalFemalePupilsInput.value = eccdeFemale + primaryFemale + specialFemale;
+    }
+
+    // Update the total pupils count (male + female)
+    updateSilnatTotalPupils();
+    calculateTeacherPupilRatio(); // Recalculate ratio
+}
+
+function calculateTeacherPupilRatio() {
+    const totalTeachers = parseInt(document.getElementById('silnat_teachers_total').value, 10) || 0;
+    const totalPupils = parseInt(document.getElementById('silnat_pupils_total').value, 10) || 0;
+    const ratioInput = document.getElementById('silnat_teacher_pupil_ratio');
+
+    if (ratioInput) {
+        if (totalTeachers > 0 && totalPupils > 0) {
+            const ratio = (totalPupils / totalTeachers).toFixed(1);
+            ratioInput.value = `1 : ${ratio}`;
+        } else {
+            ratioInput.value = 'N/A';
+        }
+    }
+}
+
 function updateSilnatTotalTeachers() {
     const maleTeachersInput = document.getElementById('silnat_teachers_male');
     const femaleTeachersInput = document.getElementById('silnat_teachers_female');
@@ -5607,6 +5577,7 @@ function updateSilnatTotalTeachers() {
 
         totalTeachersInput.value = maleCount + femaleCount;
     }
+    calculateTeacherPupilRatio(); // Recalculate ratio
 }
 
 // Function to update total non-teaching staff for SILNAT form


### PR DESCRIPTION
This commit addresses a series of bugs reported for Form 1.1:

- Fixes the collapsible section buttons by removing a duplicate JavaScript function.
- Implements automatic calculation for all 'Total' fields (teachers, non-teaching staff, pupils) by adding the necessary event handlers.
- Corrects the 'Total Pupils' calculation to be an automatic sum of ECCDE, Primary, and Special learners, and makes the field readonly.
- Automates the 'Teacher/Pupil Ratio' calculation, formats it as '1 : X', and makes the field readonly.
- Fixes all radio buttons in Section C by correcting their 'name' attributes to be unique and adding the required 'value' attributes. This resolves a major data corruption issue that was preventing successful form submissions.