### PR TITLE
fix: Correct survey type for SILNAT form submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -2170,7 +2170,7 @@ h4[onclick] {
 
         <!-- Survey Sections (initially hidden) -->
         <div id="silnatSection" class="section hidden">
-            <form id="silnat_1.1_form" onsubmit="submitSurvey(event, 'silnat_1.1')">
+            <form id="silnat_1.1_form" onsubmit="submitSurvey(event, 'silnat')">
             <div style="display: flex; align-items: center; margin-bottom: 20px;">
                 <img src="subeb.jpg" alt="LASUBEB Logo" class="survey-header-logo">
                 <h2 style="margin-left: 15px; flex-grow: 1; margin-bottom: 0;">SILNAT 1.1</h2>


### PR DESCRIPTION
The SILNAT form was being submitted with an incorrect survey type ('silnat_1.1' instead of 'silnat'), which caused it to not be displayed on the report view page.

This commit corrects the onsubmit handler for the SILNAT form to use the correct survey type, ensuring that the submitted data is processed and displayed correctly.