### PR TITLE
feat: Add specific endpoints for SILAT survey forms

### DIFF
--- a/server.js
+++ b/server.js
@@ -169,6 +169,39 @@ app.post('/api/voices', async (req, res) => {
   }
 });
 
+app.post('/api/surveys/silat_1.2', async (req, res) => {
+  try {
+    const survey = new SurveyResponse({ surveyType: 'SILAT 1.2', formData: req.body });
+    await survey.save();
+    res.status(201).json({ message: 'SILAT 1.2 survey submitted successfully!' });
+  } catch (error) {
+    console.error('Error saving SILAT 1.2 survey:', error);
+    res.status(500).json({ message: 'Submission failed.', error: error.message });
+  }
+});
+
+app.post('/api/surveys/silat_1.3', async (req, res) => {
+  try {
+    const survey = new SurveyResponse({ surveyType: 'SILAT 1.3', formData: req.body });
+    await survey.save();
+    res.status(201).json({ message: 'SILAT 1.3 survey submitted successfully!' });
+  } catch (error) {
+    console.error('Error saving SILAT 1.3 survey:', error);
+    res.status(500).json({ message: 'Submission failed.', error: error.message });
+  }
+});
+
+app.post('/api/surveys/silat_1.4', async (req, res) => {
+  try {
+    const survey = new SurveyResponse({ surveyType: 'SILAT 1.4', formData: req.body });
+    await survey.save();
+    res.status(201).json({ message: 'SILAT 1.4 survey submitted successfully!' });
+  } catch (error) {
+    console.error('Error saving SILAT 1.4 survey:', error);
+    res.status(500).json({ message: 'Submission failed.', error: error.message });
+  }
+});
+
 // Generic endpoint for other/new surveys
 app.post('/api/surveys/:type', async (req, res) => {
   try {

--- a/server.log
+++ b/server.log
@@ -1,6 +1,6 @@
-(node:10023) [MONGODB DRIVER] Warning: useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
+(node:2670) [MONGODB DRIVER] Warning: useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:10023) [MONGODB DRIVER] Warning: useUnifiedTopology is a deprecated option: useUnifiedTopology has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
+(node:2670) [MONGODB DRIVER] Warning: useUnifiedTopology is a deprecated option: useUnifiedTopology has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
 Server is running on port 3000
 Successfully connected to MongoDB
 Removed existing demo users.


### PR DESCRIPTION
This commit adds specific Express endpoints in `server.js` for the SILAT 1.2, 1.3, and 1.4 survey forms.

Previously, these forms were handled by a generic `/api/surveys/:type` endpoint. While functional, this was inconsistent with the established pattern of having specific endpoints for other forms like SILNAT, TCMATS, LORI, and VOICES.

Adding these specific endpoints improves the application's structure, maintains consistency, and allows for easier implementation of form-specific validation or processing in the future.