### PR TITLE
Fix checkbox validation in VOICES survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -3705,10 +3705,10 @@ h4[onclick] {
                         <label>c. Classroom Condition <span style="color:red;">*</span></label>
                         <div>
                             <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="beautiful" required=""> Beautiful</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="overcrowded" required=""> Overcrowded</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="bad_floor" required=""> Bad Floor</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="leaking_roof" required=""> Leaking Roof</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="bad_windows_doors" required=""> Bad windows and Doors</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="overcrowded"> Overcrowded</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="bad_floor"> Bad Floor</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="leaking_roof"> Leaking Roof</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="classroom_condition" value="bad_windows_doors"> Bad windows and Doors</label>
                         </div>
                     </div>
                     <div class="form-group">
@@ -3776,12 +3776,12 @@ h4[onclick] {
                         <label>h. Sources of Electricity <span style="color:red;">*</span></label>
                         <div>
                             <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="none" required=""> None</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn" required=""> PHCN</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator" required=""> Generator</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar" required=""> Solar</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others" required=""> Others</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills" required=""> PHCN but Disconnected because of accumulated bills</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter" required=""> PHCN but Disconnected because of lack of meter</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn"> PHCN</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator"> Generator</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar"> Solar</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others"> Others</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                         </div>
                     </div>
                     <div class="form-group">
@@ -3789,13 +3789,13 @@ h4[onclick] {
                         <div>
                             <label>Which of these Clubs and Societies is available in your School? <span style="color:red;">*</span></label>
                             <label class="checkbox-inline"><input type="checkbox" name="clubs" value="boys_scout" required=""> Boys Scout</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="girls_guide" required=""> Girls Guide</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="brigade" required=""> Brigade</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="brownies" required=""> Brownies</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="sheriff_guide" required=""> Sheriff Guide</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="young_farmers_club" required=""> Young Farmers Club</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="red_cross" required=""> Red Cross</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="none" required=""> None</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="girls_guide"> Girls Guide</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="brigade"> Brigade</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="brownies"> Brownies</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="sheriff_guide"> Sheriff Guide</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="young_farmers_club"> Young Farmers Club</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="red_cross"> Red Cross</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="clubs" value="none"> None</label>
                         </div>
                     </div>
                     <div class="form-group">
@@ -3812,12 +3812,12 @@ h4[onclick] {
                         <div>
                             <label>Which of these Sport equipment is available in your School? <span style="color:red;">*</span></label>
                             <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="football_field" required=""> Football field</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="football" required=""> Football</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="table_tennis" required=""> Table tennis</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="jersey" required=""> Jersey</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="batons" required=""> Batons</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="trophies" required=""> Trophies</label>
-                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="none" required=""> None</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="football"> Football</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="table_tennis"> Table tennis</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="jersey"> Jersey</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="batons"> Batons</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="trophies"> Trophies</label>
+                            <label class="checkbox-inline"><input type="checkbox" name="sports_equipment" value="none"> None</label>
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
The checkboxes in the VOICES survey section of `index.html` all had the `required` attribute, which forced users to select every option in a group.

This change modifies the `required` attribute on the checkboxes to only be on the first option of each group. This leverages the existing JavaScript validation to ensure at least one option is selected per group, while allowing the user to select one or more options, not all of them.