### PR TITLE
Fix: Add missing autosum functionality to SILNAT 1.1 form

### DIFF
--- a/index.html
+++ b/index.html
@@ -2310,11 +2310,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_teachers_male">Male <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_teachers_male" name="silnat_teachers_male" class="form-control" min="0" placeholder="Male" required="">
+                        <input type="number" id="silnat_teachers_male" name="silnat_teachers_male" class="form-control" min="0" placeholder="Male" required="" oninput="updateSilnatTotalTeachers()">
                     </div>
                     <div class="form-group">
                         <label for="silnat_teachers_female">Female <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_teachers_female" name="silnat_teachers_female" class="form-control" min="0" placeholder="Female" required="">
+                        <input type="number" id="silnat_teachers_female" name="silnat_teachers_female" class="form-control" min="0" placeholder="Female" required="" oninput="updateSilnatTotalTeachers()">
 
                     </div>
                     <div class="form-group">
@@ -2329,11 +2329,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_non_teaching_male">Male <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_non_teaching_male" name="silnat_non_teaching_male" class="form-control" min="0" placeholder="Male" required="">
+                        <input type="number" id="silnat_non_teaching_male" name="silnat_non_teaching_male" class="form-control" min="0" placeholder="Male" required="" oninput="updateSilnatTotalNonTeachingStaff()">
                     </div>
                     <div class="form-group">
                         <label for="silnat_non_teaching_female">Female <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_non_teaching_female" name="silnat_non_teaching_female" class="form-control" min="0" placeholder="Female" required="">
+                        <input type="number" id="silnat_non_teaching_female" name="silnat_non_teaching_female" class="form-control" min="0" placeholder="Female" required="" oninput="updateSilnatTotalNonTeachingStaff()">
 
                     </div>
                     <div class="form-group">
@@ -2350,11 +2350,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_eccde_male">Male <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_pupils_eccde_male" name="silnat_pupils_eccde_male" class="form-control" min="0" placeholder="Male" required="">
+                        <input type="number" id="silnat_pupils_eccde_male" name="silnat_pupils_eccde_male" class="form-control" min="0" placeholder="Male" required="" oninput="updateSilnatTotalPupilsEccde(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_eccde_female">Female <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_pupils_eccde_female" name="silnat_pupils_eccde_female" class="form-control" min="0" placeholder="Female" required="">
+                        <input type="number" id="silnat_pupils_eccde_female" name="silnat_pupils_eccde_female" class="form-control" min="0" placeholder="Female" required="" oninput="updateSilnatTotalPupilsEccde(); updateGrandTotalPupils();">
 
                     </div>
                     <div class="form-group">
@@ -2369,11 +2369,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_primary_male">Male <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_pupils_primary_male" name="silnat_pupils_primary_male" class="form-control" min="0" placeholder="Male" required="">
+                        <input type="number" id="silnat_pupils_primary_male" name="silnat_pupils_primary_male" class="form-control" min="0" placeholder="Male" required="" oninput="updateSilnatTotalPupilsPrimary(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_primary_female">Female <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_pupils_primary_female" name="silnat_pupils_primary_female" class="form-control" min="0" placeholder="Female" required="">
+                        <input type="number" id="silnat_pupils_primary_female" name="silnat_pupils_primary_female" class="form-control" min="0" placeholder="Female" required="" oninput="updateSilnatTotalPupilsPrimary(); updateGrandTotalPupils();">
 
                     </div>
                     <div class="form-group">
@@ -2388,11 +2388,11 @@ h4[onclick] {
                 <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                     <div class="form-group">
                         <label for="silnat_pupils_special_male">Male <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_pupils_special_male" name="silnat_pupils_special_male" class="form-control" min="0" placeholder="Male" required="">
+                        <input type="number" id="silnat_pupils_special_male" name="silnat_pupils_special_male" class="form-control" min="0" placeholder="Male" required="" oninput="updateSilnatTotalPupilsSpecial(); updateGrandTotalPupils();">
                     </div>
                     <div class="form-group">
                         <label for="silnat_pupils_special_female">Female <span style="color:red;">*</span></label>
-                        <input type="number" id="silnat_pupils_special_female" name="silnat_pupils_special_female" class="form-control" min="0" placeholder="Female" required="">
+                        <input type="number" id="silnat_pupils_special_female" name="silnat_pupils_special_female" class="form-control" min="0" placeholder="Female" required="" oninput="updateSilnatTotalPupilsSpecial(); updateGrandTotalPupils();">
 
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
The autosum feature, which automatically calculates the total when male and female counts are entered, was not functional on the SILNAT 1.1 survey form. This was due to missing `oninput` event handlers on the number input fields.

This commit adds the necessary `oninput` attributes to all relevant fields in the SILNAT 1.1 form, calling the appropriate JavaScript functions to calculate the totals for:
- Number of Teachers
- Number of Non-Teaching Staff
- ECCDE Pupils
- Primary Pupils
- Special Learners

This change restores the expected autosum functionality, improving user experience and data entry accuracy.