### PR TITLE
Fix: Correct checkbox validation to allow multiple selections

### DIFF
--- a/index.html
+++ b/index.html
@@ -936,7 +936,7 @@ h4[onclick] {
                     <label>Reason(s) for operating the classes as Multigrade: <span style="color:red;">*</span></label>
                     <div>
                         <label class="checkbox-inline"><input type="checkbox" name="silat_1_2_multigrade_reasons" value="inadequate_classrooms" required=""> Inadequate Classrooms</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="silat_1_2_multigrade_reasons" value="inadequate_teaching_staff" required=""> Inadequate Teaching Staff</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="silat_1_2_multigrade_reasons" value="inadequate_teaching_staff"> Inadequate Teaching Staff</label>
                     </div>
                 </div>
              </div>
@@ -1725,12 +1725,12 @@ h4[onclick] {
                 <div class="form-group">
                     <div>
                         <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="none" required=""> None</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn" required=""> PHCN</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator" required=""> Generator</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar" required=""> Solar</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others" required=""> Others</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills" required=""> PHCN but Disconnected because of accumulated bills</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter" required=""> PHCN but Disconnected because of lack of meter</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn"> PHCN</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator"> Generator</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar"> Solar</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others"> Others</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                     </div>
                     <div class="form-group">
                         <label for="electricity_additional_info">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>
@@ -2109,12 +2109,12 @@ h4[onclick] {
                 <h5>SOURCE OF ELECTRICITY <span style="color:red;">*</span></h5>
                 <div class="form-group">
                     <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="none" required=""> None</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="phcn" required=""> PHCN</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="generator" required=""> Generator</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="solar" required=""> Solar</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="others" required=""> Others</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="phcn_disconnected_bills" required=""> PHCN but Disconnected because of accumulated bills</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="phcn_disconnected_meter" required=""> PHCN but Disconnected because of lack of meter</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="phcn"> PHCN</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="generator"> Generator</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="solar"> Solar</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="others"> Others</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1.4" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                 </div>
                 <div class="form-group">
                     <label for="electricity_additional_info_1.4">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>
@@ -2444,7 +2444,7 @@ h4[onclick] {
                 <label>Reason(s) for operating the classes as Multigrade: <span style="color:red;">*</span></label>
                 <div>
                     <label class="checkbox-inline"><input type="checkbox" name="silnat_multigrade_reasons" value="inadequate_classrooms" required=""> Inadequate Classrooms</label>
-                    <label class="checkbox-inline"><input type="checkbox" name="silnat_multigrade_reasons" value="inadequate_teaching_staff" required=""> Inadequate Teaching Staff</label>
+                    <label class="checkbox-inline"><input type="checkbox" name="silnat_multigrade_reasons" value="inadequate_teaching_staff"> Inadequate Teaching Staff</label>
                 </div>
             </div>
             </div>
@@ -2669,12 +2669,12 @@ h4[onclick] {
                 <div class="form-group">
                     <div>
                         <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="none" required=""> None</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn" required=""> PHCN</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator" required=""> Generator</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar" required=""> Solar</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others" required=""> Others</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills" required=""> PHCN but Disconnected because of accumulated bills</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter" required=""> PHCN but Disconnected because of lack of meter</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn"> PHCN</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator"> Generator</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar"> Solar</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others"> Others</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                     </div>
                     <div class="form-group">
                         <label for="electricity_additional_info">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>


### PR DESCRIPTION
Previously, several checkbox groups in the survey forms had the `required` attribute on all options. This incorrectly forced users to select every option in the group.

This change corrects the behavior by ensuring that for required checkbox groups, only one option (typically the first) has the `required` attribute. This works with the existing JavaScript validation to enforce that at least one option is selected, while allowing the user to select one or more options freely.