### PR TITLE
Correct TCMATS survey form to enable submission.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2767,10 +2767,6 @@ h4[onclick] {
                         </select>
                     </div>
                     <div class="form-group">
-                        <label for="voices_learnerName">Learner's Name <span style="color:red;">*</span></label>
-                        <input type="text" id="voices_learnerName" name="voices_learnerName" class="form-control" required="">
-                    </div>
-                    <div class="form-group">
                         <label for="tcmats_teacherName">Teacher's Name <span style="color:red;">*</span></label>
                         <input type="text" id="tcmats_teacherName" name="tcmats_teacherName" class="form-control" required="">
                     </div>
@@ -2784,15 +2780,15 @@ h4[onclick] {
     	
 	 <div class="form-group">
                     <label for="tcmats_highestQualificaton">Highest Qualification: <span style="color:red;">*</span></label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="grade_ii" required=""> Grade II</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="nce" required=""> NCE</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="b_ed" required=""> B.Ed</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="ba_ed" required=""> BA. Ed</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="bsc_ed" required=""> B.Sc.Ed</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="hnd" required=""> HND</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="m_ed" required=""> M.Ed</label>
-                    <label class="radio-inline"><input type="radio" name="highest_qualification_1.2" value="others" required=""> Others</label>
-                    <input type="text" name="highest_qualification_other_1.2" placeholder="Specify other">
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="grade_ii" required=""> Grade II</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="nce" required=""> NCE</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="b_ed" required=""> B.Ed</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="ba_ed" required=""> BA. Ed</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="bsc_ed" required=""> B.Sc.Ed</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="hnd" required=""> HND</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="m_ed" required=""> M.Ed</label>
+                    <label class="radio-inline"><input type="radio" name="tcmats_highest_qualification" value="others" required=""> Others</label>
+                    <input type="text" name="tcmats_highest_qualification_other" placeholder="Specify other">
                 </div>
 	
     <div class="form-group">


### PR DESCRIPTION
The `tcmats` survey form in `index.html` had two issues that prevented it from being submitted correctly:

1.  An erroneous "Learner's Name" input field (`voices_learnerName`) was copied from another survey. This field was marked as `required`, which likely caused form validation to fail and blocked submission. This field has been removed.

2.  The "Highest Qualification" radio buttons had an incorrect `name` attribute (`highest_qualification_1.2`) copied from another survey. This has been corrected to `tcmats_highest_qualification` to ensure data integrity.

These changes fix the form's structure, allowing the generic validation and submission JavaScript to function as intended.