### PR TITLE
Fix: Correctly calculate total pupils in LORI survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -3053,9 +3053,9 @@ h4[onclick] {
                 <td>Number of pupils <span style="color:red;">*</span></td>
                 <td colspan="3">
                     <label for="lori_pupils_female" class="radio-inline">Female <span style="color:red;">*</span></label>
-                    <input type="number" id="lori_pupils_female" name="lori_pupils_female" class="form-control" style="width: 80px; display: inline-block;" required="" oninput="updateTotal(&#39;lori_pupils_male&#39;, &#39;lori_pupils_female&#39;, &#39;lori_pupils_total&#39;)">
+                    <input type="number" id="lori_pupils_female" name="lori_pupils_female" class="form-control" style="width: 80px; display: inline-block;" required="">
                     <label for="lori_pupils_male" class="radio-inline">Male <span style="color:red;">*</span></label>
-                    <input type="number" id="lori_pupils_male" name="lori_pupils_male" class="form-control" style="width: 80px; display: inline-block;" required="" oninput="updateTotal(&#39;lori_pupils_male&#39;, &#39;lori_pupils_female&#39;, &#39;lori_pupils_total&#39;)">
+                    <input type="number" id="lori_pupils_male" name="lori_pupils_male" class="form-control" style="width: 80px; display: inline-block;" required="">
                     <label for="lori_pupils_total" class="radio-inline">Total</label>
                     <input type="number" id="lori_pupils_total" name="lori_pupils_total" class="form-control" style="width: 80px; display: inline-block;" readonly="">
                 </td>
@@ -5728,6 +5728,9 @@ document.addEventListener('DOMContentLoaded', () => {
     setupTotalCalculation('silnat_pupils_eccde_male', 'silnat_pupils_eccde_female', 'silnat_pupils_eccde_total');
     setupTotalCalculation('silnat_pupils_primary_male', 'silnat_pupils_primary_female', 'silnat_pupils_primary_total');
     setupTotalCalculation('silnat_pupils_special_male', 'silnat_pupils_special_female', 'silnat_pupils_special_total');
+
+    // LORI totals
+    setupTotalCalculation('lori_pupils_male', 'lori_pupils_female', 'lori_pupils_total');
 
     // Grand total calculation listeners
     const grandTotalInputs = [


### PR DESCRIPTION
The total number of pupils in the LORI survey was not being automatically calculated due to an issue with how the event handlers were set up.

This commit refactors the LORI survey form to use the `setupTotalCalculation` function, which is already used by other forms in the application. This makes the implementation consistent and fixes the bug.