### PR TITLE
Remove Average Score and Descriptor fields from LORI survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -3250,9 +3250,6 @@ h4[onclick] {
                     <td><input type="radio" name="lori_b_3_j" value="3" required=""></td>
                     <td><input type="radio" name="lori_b_3_j" value="4" required=""></td>
                     <td><input type="radio" name="lori_b_3_j" value="5" required=""></td>
-                    <td><select name="lori_b_3_j_avg" class="form-control" required=""><option value="">Select Score</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option></select></td>
-                    <td><select name="lori_b_3_j_desc" class="form-control" required=""><option value="">Select Descriptor</option><option value="(poor)">(poor)</option><option value="(Fair)">(Fair)</option><option value="(Good)">(Good)</option><option value="(Very Good)">(Very Good)</option><option value="(Excellent)">(Excellent)</option></select></td>
-
                 </tr>
                 <tr>
                     <td rowspan="5">4. Relationship with learners</td>


### PR DESCRIPTION
Removes the "Average Score" and "Descriptor" fields from the "j) New words and concepts are clearly explained and related to learners’ experiences" sub-category of the LORI survey in `index.html`.