### PR TITLE
Fix: Correctly parse CSV files with quoted fields

### DIFF
--- a/dropdown.js
+++ b/dropdown.js
@@ -51,10 +51,17 @@ function parseCsvText(csvText) {
     const lines = cleanedCsvText.split('\n').filter(line => line.trim() !== '');
 
     for (let i = 1; i < lines.length; i++) {
-        const parts = lines[i].split(',');
-        if (parts.length >= 2) {
-            const key = parts[0].trim();
-            const value = parts[1].trim();
+        const line = lines[i];
+        const firstCommaIndex = line.indexOf(',');
+
+        if (firstCommaIndex > -1) {
+            const key = line.substring(0, firstCommaIndex).trim();
+            let value = line.substring(firstCommaIndex + 1).trim();
+
+            // Remove quotes if they exist at the start and end of the value
+            if (value.startsWith('"') && value.endsWith('"')) {
+                value = value.substring(1, value.length - 1);
+            }
 
             if (key && value) {
                 if (!data[key]) {


### PR DESCRIPTION
The `parseCsvText` function in `dropdown.js` was using a simple `split(',')` to parse CSV data. This caused issues when a field value contained a comma, as the value would be truncated.

This commit replaces the simple split with a more robust parsing logic that correctly handles quoted fields containing commas. This ensures that data from CSV files like `combo.csv` is parsed correctly, and the full, correct values are used in the survey dropdowns.

This fixes a bug where survey submissions for schools with commas in their names were not being populated correctly in the report module.