### PR TITLE
Fix: Remove redundant inline event handlers for auto-sum in SILAT 1.4…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1882,11 +1882,11 @@ h4[onclick] {
                     <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                         <div class="form-group">
                             <label for="staff_male_1.4">Male <span style="color:red;">*</span></label>
-                            <input type="number" id="staff_male_1.4" name="staff_male_1.4" class="form-control" min="0" placeholder="Male" required="" oninput="updateTotal('staff_male_1.4', 'staff_female_1.4', 'staff_total_1.4')">
+                            <input type="number" id="staff_male_1.4" name="staff_male_1.4" class="form-control" min="0" placeholder="Male" required="">
                         </div>
                         <div class="form-group">
                             <label for="staff_female_1.4">Female <span style="color:red;">*</span></label>
-                            <input type="number" id="staff_female_1.4" name="staff_female_1.4" class="form-control" min="0" placeholder="Female" required="" oninput="updateTotal('staff_male_1.4', 'staff_female_1.4', 'staff_total_1.4')">
+                            <input type="number" id="staff_female_1.4" name="staff_female_1.4" class="form-control" min="0" placeholder="Female" required="">
                         </div>
                         <div class="form-group">
                             <label for="staff_total_1.4">Total</label>
@@ -1900,11 +1900,11 @@ h4[onclick] {
                     <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                         <div class="form-group">
                             <label for="teachers_male_1.4">Male <span style="color:red;">*</span></label>
-                            <input type="number" id="teachers_male_1.4" name="teachers_male_1.4" class="form-control" min="0" placeholder="Male" required="" oninput="updateTotal('teachers_male_1.4', 'teachers_female_1.4', 'teachers_total_1.4')">
+                            <input type="number" id="teachers_male_1.4" name="teachers_male_1.4" class="form-control" min="0" placeholder="Male" required="">
                         </div>
                         <div class="form-group">
                             <label for="teachers_female_1.4">Female <span style="color:red;">*</span></label>
-                            <input type="number" id="teachers_female_1.4" name="teachers_female_1.4" class="form-control" min="0" placeholder="Female" required="" oninput="updateTotal('teachers_male_1.4', 'teachers_female_1.4', 'teachers_total_1.4')">
+                            <input type="number" id="teachers_female_1.4" name="teachers_female_1.4" class="form-control" min="0" placeholder="Female" required="">
                         </div>
                         <div class="form-group">
                             <label for="teachers_total_1.4">Total</label>
@@ -1918,11 +1918,11 @@ h4[onclick] {
                     <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
                         <div class="form-group">
                             <label for="non_teaching_male_1.4">Male <span style="color:red;">*</span></label>
-                            <input type="number" id="non_teaching_male_1.4" name="non_teaching_male_1.4" class="form-control" min="0" placeholder="Male" required="" oninput="updateTotal('non_teaching_male_1.4', 'non_teaching_female_1.4', 'non_teaching_total_1.4')">
+                            <input type="number" id="non_teaching_male_1.4" name="non_teaching_male_1.4" class="form-control" min="0" placeholder="Male" required="">
                         </div>
                         <div class="form-group">
                             <label for="non_teaching_female_1.4">Female <span style="color:red;">*</span></label>
-                            <input type="number" id="non_teaching_female_1.4" name="non_teaching_female_1.4" class="form-control" min="0" placeholder="Female" required="" oninput="updateTotal('non_teaching_male_1.4', 'non_teaching_female_1.4', 'non_teaching_total_1.4')">
+                            <input type="number" id="non_teaching_female_1.4" name="non_teaching_female_1.4" class="form-control" min="0" placeholder="Female" required="">
                         </div>
                         <div class="form-group">
                             <label for="non_teaching_total_1.4">Total</label>


### PR DESCRIPTION
… form

The auto-sum functionality in the SILAT 1.4 survey form was not working correctly due to redundant event handlers. The form had both inline `oninput` attributes and a `setupTotalCalculation` function that added event listeners for the same purpose.

This commit removes the inline `oninput` attributes from the `silat_1.4` form fields, leaving the `setupTotalCalculation` function as the sole handler for the auto-sum feature. This resolves the issue and makes the code cleaner and more robust.