### PR TITLE
Fix: Ensure survey data is correctly parsed on submission

### DIFF
--- a/server.js
+++ b/server.js
@@ -131,11 +131,12 @@ app.post('/api/login', async (req, res) => {
 app.post('/api/surveys/:type', async (req, res) => {
   try {
     const surveyType = req.params.type;
-
+    // Data might be nested under a 'formData' key. Let's handle that.
+    const surveyData = req.body.formData || req.body;
 
     const survey = new SurveyResponse({
       surveyType: surveyType,
-      formData: req.body,
+      formData: surveyData,
     });
 
     await survey.save();


### PR DESCRIPTION
The report component was not functional because survey data was not being correctly aggregated. This was due to an inconsistency in how survey data was being saved to the database. Some submissions may have been sending data nested under a `formData` key, while the reporting components expected a flat structure.

This change updates the survey submission endpoint in `server.js` to handle both flat and nested data. It checks for the existence of a `formData` key in the request body and unpacks it if present, ensuring that the data is always saved in a consistent, flat format. This allows the reporting components to correctly parse and display the survey data.