### PR TITLE
feat: Add detailed logging to survey submission

### DIFF
--- a/server.js
+++ b/server.js
@@ -131,20 +131,25 @@ app.post('/api/login', async (req, res) => {
 app.post('/api/surveys/:type', async (req, res) => {
   try {
     const surveyType = req.params.type;
+    console.log(`[${new Date().toISOString()}] Received submission for survey type: ${surveyType}`);
+    console.log(`[${new Date().toISOString()}] Request Body:`, JSON.stringify(req.body, null, 2));
+
     // Data might be nested under a 'formData' key. Let's handle that.
     const surveyData = req.body.formData || req.body;
+    console.log(`[${new Date().toISOString()}] Parsed survey data:`, JSON.stringify(surveyData, null, 2));
 
     const survey = new SurveyResponse({
       surveyType: surveyType,
       formData: surveyData,
     });
 
+    console.log(`[${new Date().toISOString()}] Attempting to save survey...`);
     await survey.save();
-    console.log(`Successfully saved survey of type: ${surveyType}`);
-    res.status(201).json({ message: `${surveyType} survey submitted successfully!` });
+    console.log(`[${new Date().toISOString()}] Successfully saved survey of type: ${surveyType} with ID: ${survey._id}`);
+    res.status(201).json({ message: `${surveyType} survey submitted successfully!`, surveyId: survey._id });
   } catch (error) {
     const surveyType = req.params.type;
-    console.error(`Error saving ${surveyType} survey:`, error);
+    console.error(`[${new Date().toISOString()}] Error saving ${surveyType} survey:`, error);
     res.status(500).json({ message: 'Submission failed.', error: error.message });
   }
 });


### PR DESCRIPTION
To diagnose an issue where survey submissions are not appearing in reports, this change adds detailed logging to the `/api/surveys/:type` endpoint in `server.js`.

The new logs will capture:
- The timestamp of the submission
- The survey type
- The full request body as a JSON string
- The parsed survey data that will be saved
- A confirmation message upon successful save, including the new survey's ID
- Any errors that occur during the save operation

This will provide crucial information for debugging the data flow and identifying why the reports are not being populated.