### PR TITLE
Fix(surveys): Correctly handle multi-value fields and UI totals

### DIFF
--- a/index.html
+++ b/index.html
@@ -5422,7 +5422,15 @@ async function submitSurvey(event, surveyType) {
     }
 
     const formData = new FormData(form);
-    const data = Object.fromEntries(formData.entries());
+    const data = {};
+    for (const key of new Set(Array.from(formData.keys()))) {
+        const values = formData.getAll(key);
+        if (values.length > 1) {
+            data[key] = values;
+        } else {
+            data[key] = values[0];
+        }
+    }
 
     const fileInput = form.querySelector('input[type="file"]');
     if (fileInput && fileInput.files.length > 0) {
@@ -5823,6 +5831,9 @@ function setupTotalCalculation(maleId, femaleId, totalId) {
     if (femaleInput) {
         femaleInput.addEventListener('input', updateTotal);
     }
+
+    // Trigger the calculation once on setup to handle pre-filled values
+    updateTotal();
 }
 
 function updateSilnatTotalPupils() {


### PR DESCRIPTION
This commit addresses two issues:

1. The survey submission logic in `index.html` was using `Object.fromEntries` on `FormData`, which incorrectly handles fields with multiple values (like checkboxes). This resulted in data loss, causing submitted surveys to be incomplete and preventing them from being correctly aggregated in the reports. The `submitSurvey` function has been updated to correctly iterate over form entries and collect all values for a given field.

2. A UI bug was present where total fields on the survey forms were not calculated on initial load, only on user input. The `setupTotalCalculation` function has been modified to compute the total immediately upon setup, ensuring the UI is always in a correct state.