### PR TITLE
Feat: Implement Report Aggregation and Summary View

### DIFF
--- a/reports/lori.html
+++ b/reports/lori.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LORI Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>LORI Survey Reports</span>
+                <span>LORI Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>LORI Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>LORI Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/lori.js
+++ b/reports/lori.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.lori_school_name || 'N/A';
-    const respondentName = formData.lori_teacher_name || 'N/A';
-    const lga = formData.lori_lgea || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/lori', {
+    fetch('/api/reports/lori/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,154 +23,87 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No LORI reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No LORI reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching LORI reports:', error);
+        console.error('Error fetching LORI summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Years Experience</h3>
+                <p>${summary.avgYearsExperience}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Rating (Content Relevancy)</h3>
+                <p>${summary.avgRating_b_1_a}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Rating (Content Delivery)</h3>
+                <p>${summary.avgRating_b_1_b}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Location Distribution', summary.locationCounts);
+    html += createTable('Highest Qualifications', summary.qualificationCounts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("LORI Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('lori-survey-reports.pdf');
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const loriFieldMapping = {
-        "lori_b_1_a": { standard: "1. Subject content knowledge", subCategory: "a) The content is relevant" },
-        "lori_b_1_b": { standard: "1. Subject content knowledge", subCategory: "b) The content is delivered logically and sequentially" },
-        "lori_b_2_a": { standard: "2. Planning the lesson", subCategory: "a) The teacher prepared a lesson plan" },
-        "lori_b_2_b": { standard: "2. Planning the lesson", subCategory: "b) The introduction was stimulating and aroused the interest and curiosity of the learners" },
-        "lori_b_2_c": { standard: "2. Planning the lesson", subCategory: "c) The teacher referred to previous lessons and skills" },
-        "lori_b_3_a": { standard: "3. Presentation and pedagogy", subCategory: "a) Every learner is involved in learning and enjoying it" },
-        "lori_b_3_b": { standard: "3. Presentation and pedagogy", subCategory: "b) The teacher uses a variety of instructional materials to explain the concept" },
-        "lori_b_3_c": { standard: "3. Presentation and pedagogy", subCategory: "c) The learners use a variety of instructional materials to practice the concept" },
-        "lori_b_3_d": { standard: "3. Presentation and pedagogy", subCategory: "d) The learners have relevant text/workbooks" },
-        "lori_b_3_e": { standard: "3. Presentation and pedagogy", subCategory: "e) The learners have relevant writing materials such as pencils, biro, colouring pens, etc." },
-        "lori_b_3_f": { standard: "3. Presentation and pedagogy", subCategory: "f) The teacher uses /displays audio-visual materials in the class" },
-        "lori_b_3_g": { standard: "3. Presentation and pedagogy", subCategory: "g) The teacher uses various ways of grouping learners" },
-        "lori_b_3_h": { standard: "3. Presentation and pedagogy", subCategory: "h) The teacher uses language that is relevant and understandable to the learners" },
-        "lori_b_3_i": { standard: "3. Presentation and pedagogy", subCategory: "i) The teacher gives clear instructions to the learners" },
-        "lori_b_3_j": { standard: "3. Presentation and pedagogy", subCategory: "j) New words and concepts are clearly explained and related to learners’ experiences" },
-        "lori_b_4_a": { standard: "4. Relationship with learners", subCategory: "a) The teacher uses learners’ names when addressing them individually" },
-        "lori_b_4_b": { standard: "4. Relationship with learners", subCategory: "b) The teacher is fair and inclusive in their teaching and feedback" },
-        "lori_b_4_c": { standard: "4. Relationship with learners", subCategory: "c) The teacher has empathy for the learners" },
-        "lori_b_4_d": { standard: "4. Relationship with learners", subCategory: "d) The teacher responds to individual learners according to their need" },
-        "lori_b_4_e": { standard: "4. Relationship with learners", subCategory: "e) The teacher is a role model to the learners" },
-        "lori_b_5_a": { standard: "5. Class management", subCategory: "a) Every learner can see the teacher and the board" },
-        "lori_b_5_b": { standard: "5. Class management", subCategory: "b) The teacher praises and rewards the learners" },
-        "lori_b_5_c": { standard: "5. Class management", subCategory: "c) The teacher encourages good behaviour among learners" },
-        "lori_b_5_d": { standard: "5. Class management", subCategory: "d) The teacher is confident in his/her presentation" },
-        "lori_b_5_e": { standard: "5. Class management", subCategory: "e) The teacher does not use a cane, use physical force, or threatens learners" },
-        "lori_b_6_a": { standard: "6. Evaluation of learning", subCategory: "a) The lesson objectives are clearly stated at the beginning of the lesson" },
-        "lori_b_6_b": { standard: "6. Evaluation of learning", subCategory: "b) The teacher walks around the room for effective teaching and learning" },
-        "lori_b_6_c": { standard: "6. Evaluation of learning", subCategory: "c) The teacher uses a variety of assessment techniques" },
-        "lori_b_6_d": { standard: "6. Evaluation of learning", subCategory: "d) The teacher invites learners to ask questions and responds appropriately" },
-        "lori_b_6_e": { standard: "6. Evaluation of learning", subCategory: "e) The teacher checks the achievement of the lesson objectives at the end of the lesson through relevant text" },
-        "lori_b_6_f": { standard: "6. Evaluation of learning", subCategory: "f) The teacher gave relevant homework if need be" },
-        "lori_b_7":   { standard: "7. Overall Assessment", subCategory: "" },
-    };
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheetData = allSurveys.flatMap(survey => {
-        const { createdAt, formData } = survey;
-        const loriRows = [];
-        const baseData = {
-            'Survey Type': 'lori',
-            'Submission Date': new Date(createdAt).toLocaleString(),
-        };
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-        // Add all non-lori_b fields to the base data
-        for (const [key, value] of Object.entries(formData)) {
-            if (!key.startsWith('lori_b_')) {
-                if (typeof value !== 'object' || value === null) {
-                    baseData[key] = value;
-                } else {
-                    baseData[key] = JSON.stringify(value);
-                }
-            }
-        }
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
 
-        // Create a new row for each lori_b field
-        for (const [key, value] of Object.entries(formData)) {
-            if (key.startsWith('lori_b_')) {
-                const mapping = loriFieldMapping[key];
-                if (mapping) {
-                    const newRow = {
-                        ...baseData,
-                        'Teacher Standard': mapping.standard,
-                        'Sub-category': mapping.subCategory,
-                        'Rating (1-5)': value
-                    };
-                    loriRows.push(newRow);
-                }
-            }
-        }
-        return loriRows;
-    });
-
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "LORI Reports");
-
-    XLSX.writeFile(workbook, "lori-survey-reports.xlsx");
+    return tableHtml;
 }

--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -3,10 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SILAT_1.1 Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <title>SILAT 1.1 Survey Reports</title>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>SILAT_1.1 Survey Reports</span>
+                <span>SILAT 1.1 Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>SILAT_1.1 Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>SILAT 1.1 Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.schoolName || 'N/A';
-    const respondentName = formData.silnat_a_ht_name || 'N/A';
-    const lga = formData.localGov || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.1', {
+    fetch('/api/reports/silat_1.1/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,104 +23,78 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.1 reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No SILAT 1.1 reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.1 reports:', error);
+        console.error('Error fetching SILAT 1.1 summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Gender Distribution', summary.genderCounts);
+    html += createTable('Marital Status', summary.maritalStatusCounts);
+    html += createTable('Highest Qualifications', summary.qualificationCounts);
+    html += createTable('Years of Experience', summary.experienceCounts);
+    html += createTable('Discipline: Getting teachers and learners to obey rules', summary.disciplineACounts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("SILAT_1.1 Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('silat_1.1-survey-reports.pdf');
-}
-
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const worksheetData = allSurveys.map(survey => {
-        const flattenedFormData = flattenObject(survey.formData);
-        const rowData = {
-            'Survey Type': survey.surveyType,
-            'Submission Date': new Date(survey.createdAt).toLocaleString(),
-            ...flattenedFormData
-        };
-        return rowData;
-    });
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "Survey Reports");
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-    XLSX.writeFile(workbook, "silat_1.1-survey-reports.xlsx");
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    return tableHtml;
 }

--- a/reports/silat_1.2.html
+++ b/reports/silat_1.2.html
@@ -3,10 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SILAT_1.2 Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <title>SILAT 1.2 Survey Reports</title>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>SILAT_1.2 Survey Reports</span>
+                <span>SILAT 1.2 Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>SILAT_1.2 Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>SILAT 1.2 Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.silat_1_2_schoolName || 'N/A';
-    const respondentName = formData.silnat_a_ht_name || 'N/A';
-    const lga = formData.silat_1_2_localGov || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.2', {
+    fetch('/api/reports/silat_1.2/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,104 +23,79 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.2 reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No SILAT 1.2 reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.2 reports:', error);
+        console.error('Error fetching SILAT 1.2 summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+            <div class="card">
+                <h3>Total Teachers</h3>
+                <p>${summary.totalTeachers}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Location Distribution', summary.locationCounts);
+    html += createTable('Special Learners', summary.specialLearnersCounts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("SILAT_1.2 Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('silat_1.2-survey-reports.pdf');
-}
-
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const worksheetData = allSurveys.map(survey => {
-        const flattenedFormData = flattenObject(survey.formData);
-        const rowData = {
-            'Survey Type': survey.surveyType,
-            'Submission Date': new Date(survey.createdAt).toLocaleString(),
-            ...flattenedFormData
-        };
-        return rowData;
-    });
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "Survey Reports");
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-    XLSX.writeFile(workbook, "silat_1.2-survey-reports.xlsx");
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    return tableHtml;
 }

--- a/reports/silat_1.3.html
+++ b/reports/silat_1.3.html
@@ -3,10 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SILAT_1.3 Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <title>SILAT 1.3 Survey Reports</title>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>SILAT_1.3 Survey Reports</span>
+                <span>SILAT 1.3 Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>SILAT_1.3 Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>SILAT 1.3 Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.silat13_school_name || 'N/A';
-    const respondentName = formData.silnat_a_ht_name || 'N/A';
-    const lga = formData.silat13_lgea || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.3', {
+    fetch('/api/reports/silat_1.3/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,104 +23,79 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.3 reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No SILAT 1.3 reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.3 reports:', error);
+        console.error('Error fetching SILAT 1.3 summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+            <div class="card">
+                <h3>Total Instructors</h3>
+                <p>${summary.totalInstructors}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Location Distribution', summary.locationCounts);
+    html += createTable('Highest Qualifications', summary.qualificationCounts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("SILAT_1.3 Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('silat_1.3-survey-reports.pdf');
-}
-
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const worksheetData = allSurveys.map(survey => {
-        const flattenedFormData = flattenObject(survey.formData);
-        const rowData = {
-            'Survey Type': survey.surveyType,
-            'Submission Date': new Date(survey.createdAt).toLocaleString(),
-            ...flattenedFormData
-        };
-        return rowData;
-    });
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "Survey Reports");
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-    XLSX.writeFile(workbook, "silat_1.3-survey-reports.xlsx");
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    return tableHtml;
 }

--- a/reports/silat_1.4.html
+++ b/reports/silat_1.4.html
@@ -3,10 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SILAT_1.4 Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <title>SILAT 1.4 Survey Reports</title>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>SILAT_1.4 Survey Reports</span>
+                <span>SILAT 1.4 Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>SILAT_1.4 Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>SILAT 1.4 Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.silat_1_4_schoolName || 'N/A';
-    const respondentName = 'N/A'; // LGEA-level survey
-    const lga = formData.silat_1_4_localGov || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.4', {
+    fetch('/api/reports/silat_1.4/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,104 +23,79 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.4 reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No SILAT 1.4 reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.4 reports:', error);
+        console.error('Error fetching SILAT 1.4 summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+            <div class="card">
+                <h3>Total Staff</h3>
+                <p>${summary.totalStaff}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Location Distribution', summary.locationCounts);
+    html += createTable('Highest Qualifications', summary.qualificationCounts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("SILAT_1.4 Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('silat_1.4-survey-reports.pdf');
-}
-
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const worksheetData = allSurveys.map(survey => {
-        const flattenedFormData = flattenObject(survey.formData);
-        const rowData = {
-            'Survey Type': survey.surveyType,
-            'Submission Date': new Date(survey.createdAt).toLocaleString(),
-            ...flattenedFormData
-        };
-        return rowData;
-    });
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "Survey Reports");
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-    XLSX.writeFile(workbook, "silat_1.4-survey-reports.xlsx");
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    return tableHtml;
 }

--- a/reports/tcmats.html
+++ b/reports/tcmats.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TCMATS Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>TCMATS Survey Reports</span>
+                <span>TCMATS Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>TCMATS Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>TCMATS Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.tcmats_schoolName || 'N/A';
-    const respondentName = formData.tcmats_teacherName || 'N/A';
-    const lga = formData.tcmats_lgea || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/tcmats', {
+    fetch('/api/reports/tcmats/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,104 +23,89 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No TCMATS reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No TCMATS reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching TCMATS reports:', error);
+        console.error('Error fetching TCMATS summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Periods Per Week</h3>
+                <p>${summary.avgPeriodsPerWeek}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Pupils In Class</h3>
+                <p>${summary.avgPupilsInClass}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Location Distribution', summary.locationCounts);
+    html += createTable('Institution Types', summary.institutionCounts);
+    html += createTable('Highest Qualifications', summary.qualificationCounts);
+    html += createTable('Gender Distribution', summary.genderCounts);
+    html += createTable('Teaching Experience', summary.teachingExperienceCounts);
+    html += createTable('Class Descriptions', summary.classDescriptionCounts);
+    html += createTable('Lesson Preparation (Item 1)', summary.lessonPrep1Counts);
+    html += createTable('Subject Mastery (Item 2)', summary.subjectMastery2Counts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("TCMATS Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('tcmats-survey-reports.pdf');
-}
-
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const worksheetData = allSurveys.map(survey => {
-        const flattenedFormData = flattenObject(survey.formData);
-        const rowData = {
-            'Survey Type': survey.surveyType,
-            'Submission Date': new Date(survey.createdAt).toLocaleString(),
-            ...flattenedFormData
-        };
-        return rowData;
-    });
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "Survey Reports");
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-    XLSX.writeFile(workbook, "tcmats-survey-reports.xlsx");
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    return tableHtml;
 }

--- a/reports/voices.html
+++ b/reports/voices.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VOICES Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -14,41 +11,18 @@
         <div class="header">
             <div class="logo">
                 <img src="/subeb.jpg" alt="Lagos State Logo">
-                <span>VOICES Survey Reports</span>
+                <span>VOICES Survey Summary</span>
             </div>
             <a href="/reports/index.html" class="btn-secondary">Back to Dashboard</a>
         </div>
         <div class="content-area">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <h2>VOICES Reports</h2>
-                <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
-                </div>
+                <h2>VOICES Summary</h2>
             </div>
-            <table class="data-table" id="reportsTable">
-                <thead>
-                    <tr>
-                        <th>School Name / LGEA</th>
-                        <th>Respondent Name</th>
-                        <th>Submission Date</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- Data will be inserted here by JavaScript -->
-                </tbody>
-            </table>
-            <div id="loadingMessage">Loading reports...</div>
-        </div>
-    </div>
-
-    <!-- Modal for viewing details -->
-    <div id="detailsModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" onclick="closeModal()">&times;</span>
-            <h3>Survey Details</h3>
-            <pre id="modal-data" style="white-space: pre-wrap; word-wrap: break-word; background: #f4f4f4; padding: 15px; border-radius: 5px; margin-top: 15px;"></pre>
+            <div id="summaryContainer">
+                <!-- Summary data will be inserted here by JavaScript -->
+            </div>
+            <div id="loadingMessage">Loading summary...</div>
         </div>
     </div>
 

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -1,15 +1,5 @@
-let allSurveys = []; // Global variable to hold survey data for exports
-
-function getSurveyDisplayData(survey) {
-    const formData = survey.formData || {};
-    const schoolName = formData.voices_schoolName || 'N/A';
-    const respondentName = 'N/A'; // No specific respondent name in VOICES form
-    const lga = formData.voices_lgea || 'N/A';
-    return { schoolName, respondentName, lga };
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    const tableBody = document.querySelector('#reportsTable tbody');
+    const summaryContainer = document.getElementById('summaryContainer');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
 
@@ -18,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/voices', {
+    fetch('/api/reports/voices/summary', {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -33,104 +23,84 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
-        allSurveys = surveys; // Store data for export functions
+    .then(summary => {
         loadingMessage.style.display = 'none';
-        if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No VOICES reports found.</td></tr>';
+        if (summary.totalSubmissions === 0) {
+            summaryContainer.innerHTML = '<p>No VOICES reports found.</p>';
             return;
         }
 
-        tableBody.innerHTML = ''; // Clear previous content
-
-        surveys.forEach(survey => {
-            const row = tableBody.insertRow();
-            const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
-
-            row.innerHTML = `
-                <td>${schoolName} (${lga})</td>
-                <td>${respondentName}</td>
-                <td>${new Date(survey.createdAt).toLocaleString()}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
-            `;
-        });
+        renderSummary(summary);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
-            loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
+            loadingMessage.innerHTML = '<strong>Failed to load summary.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching VOICES reports:', error);
+        console.error('Error fetching VOICES summary:', error);
     });
 });
 
-const modal = document.getElementById('detailsModal');
-const modalData = document.getElementById('modal-data');
+function renderSummary(summary) {
+    const summaryContainer = document.getElementById('summaryContainer');
 
-function viewDetails(survey) {
-    modalData.textContent = JSON.stringify(survey, null, 2);
-    modal.style.display = "block";
+    let html = `
+        <div class="summary-cards">
+            <div class="card">
+                <h3>Total Submissions</h3>
+                <p>${summary.totalSubmissions}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Participation (Asking Questions)</h3>
+                <p>${summary.avgParticipation1}</p>
+            </div>
+            <div class="card">
+                <h3>Avg. Participation (Answering Questions)</h3>
+                <p>${summary.avgParticipation2}</p>
+            </div>
+        </div>
+    `;
+
+    html += '<h3>Breakdowns</h3>';
+
+    html += createTable('Institution Types', summary.institutionCounts);
+    html += createTable('Gender Distribution', summary.genderCounts);
+    html += createTable('Distance from Home', summary.distanceCounts);
+
+    summaryContainer.innerHTML = html;
 }
 
-function closeModal() {
-    modal.style.display = "none";
-}
-
-window.onclick = function(event) {
-    if (event.target == modal) {
-        closeModal();
-    }
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
-    }
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    doc.text("VOICES Survey Reports", 14, 16);
-
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
-
-    doc.save('voices-survey-reports.pdf');
-}
-
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
-        alert("No data to export.");
-        return;
+function createTable(title, data) {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
     }
 
-    const worksheetData = allSurveys.map(survey => {
-        const flattenedFormData = flattenObject(survey.formData);
-        const rowData = {
-            'Survey Type': survey.surveyType,
-            'Submission Date': new Date(survey.createdAt).toLocaleString(),
-            ...flattenedFormData
-        };
-        return rowData;
-    });
+    let tableHtml = `
+        <div class="summary-table">
+            <h4>${title}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
 
-    const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, "Survey Reports");
+    for (const [key, value] of Object.entries(data)) {
+        tableHtml += `
+            <tr>
+                <td>${key}</td>
+                <td>${value}</td>
+            </tr>
+        `;
+    }
 
-    XLSX.writeFile(workbook, "voices-survey-reports.xlsx");
+    tableHtml += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    return tableHtml;
 }


### PR DESCRIPTION
This change refactors the survey reporting feature to display aggregated summaries instead of individual submissions, addressing the issue where reports were considered non-functional.

Previously, the report pages for each survey type would fetch all individual submissions and display them in a simple table. This was not a useful way to view the data and did not provide any insights.

This commit introduces the following changes:

1.  **Backend Aggregation:**
    -   A new API endpoint, `/api/reports/:type/summary`, has been added to `server.js`.
    -   This endpoint uses the MongoDB aggregation pipeline to process the raw survey data on the server.
    -   For each survey type, a custom aggregation pipeline was created to calculate summary statistics, such as counting categorical responses and averaging numerical data.

2.  **Frontend Summary View:**
    -   The frontend JavaScript for each report (`tcmats.js`, `silat_1.1.js`, etc.) has been updated to fetch data from the new `/summary` endpoint.
    -   The corresponding HTML files have been modified to replace the old table with a new layout that includes:
        -   Summary cards for key metrics (e.g., total submissions, averages).
        -   Breakdown tables for categorical data (e.g., gender distribution, qualification counts).
    -   The old functionality for viewing individual submission details in a modal and exporting raw data to PDF/Excel has been removed as it is no longer relevant to the new summary view.

These changes provide a much more functional and insightful reporting experience for the user.