### PR TITLE
Fix: Correctly populate checkboxes from URL parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -4180,18 +4180,27 @@ window.onload = async function() {
                 const values = urlParams.getAll(key);
                 processedKeys.add(key);
 
-                if (elements.constructor === RadioNodeList) { // For radio buttons
-                    for (const radio of elements) {
-                        if (radio.value === values[0]) {
-                            radio.checked = true;
-                            break;
+                if (elements.constructor === RadioNodeList) {
+                    // This could be radio buttons or checkboxes. Check the type.
+                    if (elements[0] && elements[0].type === 'checkbox') {
+                        // Handle as checkboxes
+                        for (const checkbox of elements) {
+                            if (values.includes(checkbox.value)) {
+                                checkbox.checked = true;
+                            }
+                        }
+                    } else {
+                        // Handle as radio buttons
+                        for (const radio of elements) {
+                            if (radio.value === values[0]) {
+                                radio.checked = true;
+                                break;
+                            }
                         }
                     }
-                } else if (elements.length && elements[0].type === 'checkbox') { // For checkboxes
-                    for (const checkbox of elements) {
-                        if (values.includes(checkbox.value)) {
-                            checkbox.checked = true;
-                        }
+                } else if (elements.type === 'checkbox') { // handle single checkbox
+                    if (values.includes(elements.value)) {
+                        elements.checked = true;
                     }
                 } else { // For text, select, textarea etc.
                     elements.value = decodeURIComponent(values[0]);


### PR DESCRIPTION
The JavaScript logic for populating survey forms from URL parameters had a bug where it would not correctly handle checkboxes with multiple values. A `RadioNodeList` is returned for both radio button groups and checkbox groups, but the code was treating both as radio buttons, only processing the first value from the URL and then breaking the loop.

This change modifies the logic to inspect the type of the elements within the `RadioNodeList`. If they are checkboxes, it iterates through all values from the URL and checks all corresponding boxes. If they are radio buttons, it retains the original behavior of checking only the first matching value. This ensures that when a URL contains multiple values for a set of checkboxes (e.g., `?classroom_condition=a&classroom_condition=b`), all specified checkboxes are correctly checked on the report page.