### PR TITLE
Fix(reports): Redirect voices.html to voices_report.html when query p…

### DIFF
--- a/reports/voices.html
+++ b/reports/voices.html
@@ -8,6 +8,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <link rel="stylesheet" href="/reports/style.css">
+    <script>
+        // Check if there are any URL parameters intended for a single report
+        if (window.location.search) {
+            // If so, redirect to the correct single report page
+            window.location.href = 'voices_report.html' + window.location.search;
+        }
+    </script>
 </head>
 <body>
     <div class="container">

--- a/reports/voices_report.html
+++ b/reports/voices_report.html
@@ -13,7 +13,7 @@
                 <img src="/subeb.jpg" alt="Lagos State Logo">
                 <span>VOICES School Assessment Report</span>
             </div>
-            <a href="/reports/voices.html" class="btn-secondary">Back to VOICES Reports</a>
+            <a href="/reports/index.html" class="btn-secondary">Back to Reports Dashboard</a>
         </div>
         <div class="content-area">
             <h2>Report Details</h2>


### PR DESCRIPTION
…arameters are present

This commit fixes an issue where the voices report page was not being populated when a user navigated to it with URL query parameters. The `voices.html` page is a list of all reports and does not handle single report view from query parameters. The `voices_report.html` is the correct page for this purpose.

A javascript redirect has been added to `voices.html` to redirect users to `voices_report.html` if any query parameters are present. Additionally, the 'Back' button on `voices_report.html` has been updated to point to the main reports dashboard.