### PR TITLE
Fix JavaScript error and duplicate HTML IDs in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1048,144 +1048,144 @@ h4[onclick] {
                 <div class="form-group">
                     <label>Signboard <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="available_good" required=""> Available and in good condition</label>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="available_not_good" required=""> Available but not in good condition</label>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="not_available" required=""> Not Available</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_2" value="available_good" required=""> Available and in good condition</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_2" value="available_not_good" required=""> Available but not in good condition</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_2" value="not_available" required=""> Not Available</label>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Teachers’ Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="teachers_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_available" name="teachers_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="teachers_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_good" name="teachers_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="teachers_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_required" name="teachers_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_available_1_2">Number Available <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_available_1_2" name="teachers_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_good_1_2">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_good_1_2" name="teachers_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_required_1_2">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_required_1_2" name="teachers_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">ECCDE Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="eccde_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_available" name="eccde_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="eccde_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_good" name="eccde_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="eccde_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_required" name="eccde_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="eccde_furniture_available_1_2">Number Available <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_available_1_2" name="eccde_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="eccde_furniture_good_1_2">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_good_1_2" name="eccde_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="eccde_furniture_required_1_2">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_required_1_2" name="eccde_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Primary Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="primary_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="primary_furniture_available" name="primary_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="primary_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="primary_furniture_good" name="primary_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="primary_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="primary_furniture_required" name="primary_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="primary_furniture_available_1_2">Number Available <span style="color:red;">*</span></label><input type="number" id="primary_furniture_available_1_2" name="primary_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="primary_furniture_good_1_2">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="primary_furniture_good_1_2" name="primary_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="primary_furniture_required_1_2">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="primary_furniture_required_1_2" name="primary_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Classroom Condition <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="classroom_available">Number Available <span style="color:red;">*</span></label><input type="number" id="classroom_available" name="classroom_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="classroom_good" name="classroom_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_minor_repair">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="classroom_minor_repair" name="classroom_minor_repair" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_major_repair">Number in need of Major Repair/Renovation <span style="color:red;">*</span></label><input type="number" id="classroom_major_repair" name="classroom_major_repair" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_required">Number of Additional Classroom Required <span style="color:red;">*</span></label><input type="number" id="classroom_required" name="classroom_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_available_1_2">Number Available <span style="color:red;">*</span></label><input type="number" id="classroom_available_1_2" name="classroom_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_good_1_2">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="classroom_good_1_2" name="classroom_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_minor_repair_1_2">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="classroom_minor_repair_1_2" name="classroom_minor_repair" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_major_repair_1_2">Number in need of Major Repair/Renovation <span style="color:red;">*</span></label><input type="number" id="classroom_major_repair_1_2" name="classroom_major_repair" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_required_1_2">Number of Additional Classroom Required <span style="color:red;">*</span></label><input type="number" id="classroom_required_1_2" name="classroom_required" class="form-control" min="0" required=""></div>
                     </div>
                     <div class="form-group">
-                        <label for="classroom_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                        <textarea id="classroom_repair_description" name="classroom_repair_description" class="form-control" rows="2" required=""></textarea>
+                        <label for="classroom_repair_description_1_2">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                        <textarea id="classroom_repair_description_1_2" name="classroom_repair_description" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
-                <h4 id="fencing_header_1_1">2. FENCING <span style="color:red;">*</span></h4>
+                <h4 id="fencing_header_1_2">2. FENCING <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <label>a. Shared Facility <span style="color:red;">*</span></label>
                     <div>
                         <label>Is the school located within a school Complex? <span style="color:red;">*</span></label>
-                        <label class="radio-inline"><input type="radio" name="shared_facility" value="yes" required onchange="handleSharedFacilityChange(this)"> Yes</label>
-                        <label class="radio-inline"><input type="radio" name="shared_facility" value="no" required onchange="handleSharedFacilityChange(this)"> No</label>
+                        <label class="radio-inline"><input type="radio" name="shared_facility_1_2" value="yes" required onchange="handleSharedFacilityChange(this)"> Yes</label>
+                        <label class="radio-inline"><input type="radio" name="shared_facility_1_2" value="no" required onchange="handleSharedFacilityChange(this)"> No</label>
                     </div>
-                    <div class="form-group" id="shared_facility_schools_wrapper" style="display: none;">
-                        <label for="shared_facility_schools">If Yes, Kindly list other Schools within the Complex <span id="shared_facility_schools_asterisk" style="color:red; display:none;">*</span></label>
-                        <textarea id="shared_facility_schools" name="shared_facility_schools" class="form-control" rows="4"></textarea>
+                    <div class="form-group" id="shared_facility_schools_wrapper_1_2" style="display: none;">
+                        <label for="shared_facility_schools_1_2">If Yes, Kindly list other Schools within the Complex <span id="shared_facility_schools_asterisk" style="color:red; display:none;">*</span></label>
+                        <textarea id="shared_facility_schools_1_2" name="shared_facility_schools" class="form-control" rows="4"></textarea>
                     </div>
                 </div>
                 <div class="form-group">
                     <label>b. Does the school have perimeter fence: <span style="color:red;">*</span></label>
-                    <label class="radio-inline"><input type="radio" name="perimeter_fence" value="yes" required onchange="handlePerimeterFenceChange(this)"> Yes</label>
-                    <label class="radio-inline"><input type="radio" name="perimeter_fence" value="no" required onchange="handlePerimeterFenceChange(this)"> No</label>
+                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1_2" value="yes" required onchange="handlePerimeterFenceChange(this)"> Yes</label>
+                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1_2" value="no" required onchange="handlePerimeterFenceChange(this)"> No</label>
                 </div>
-                <div class="form-group" id="fence_condition_wrapper" style="display: none;">
+                <div class="form-group" id="fence_condition_wrapper_1_2" style="display: none;">
                     <label>If Yes, in what State? <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="fence_condition" value="good"> In Good Condition</label>
-                        <label class="radio-inline"><input type="radio" name="fence_condition" value="minor_repair"> Need Minor Repair</label>
-                        <label class="radio-inline"><input type="radio" name="fence_condition" value="major_repair"> Need Major Repair</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_2" value="good"> In Good Condition</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_2" value="minor_repair"> Need Minor Repair</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_2" value="major_repair"> Need Major Repair</label>
                     </div>
                 </div>
-                <div class="form-group" id="fence_repair_wrapper" style="display: none;">
-                    <label for="fence_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                    <textarea id="fence_repair_description" name="fence_repair_description" class="form-control" rows="2"></textarea>
+                <div class="form-group" id="fence_repair_wrapper_1_2" style="display: none;">
+                    <label for="fence_repair_description_1_2">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                    <textarea id="fence_repair_description_1_2" name="fence_repair_description" class="form-control" rows="2"></textarea>
                 </div>
-                <div class="form-group" id="school_perimeter_wrapper" style="display: none;">
-                    <label for="school_perimeter">If No, what is the perimeter of the School? <span id="school_perimeter_asterisk" style="color:red; display:none;">*</span></label>
-                    <input type="text" id="school_perimeter" name="school_perimeter" class="form-control">
+                <div class="form-group" id="school_perimeter_wrapper_1_2" style="display: none;">
+                    <label for="school_perimeter_1_2">If No, what is the perimeter of the School? <span id="school_perimeter_asterisk" style="color:red; display:none;">*</span></label>
+                    <input type="text" id="school_perimeter_1_2" name="school_perimeter" class="form-control">
                 </div>
 
                 <h4>3. TOILET FACILITIES</h4>
                 <div class="form-group">
                     <label>Type of Toilet:</label>
                     <div>
-                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type" value="pit"> Pit</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type" value="wc"> WC</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type" value="squat_water_flush"> Squat Water flush</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type" value="none"> None</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type_1_2" value="pit"> Pit</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type_1_2" value="wc"> WC</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type_1_2" value="squat_water_flush"> Squat Water flush</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="toilet_type_1_2" value="none"> None</label>
                     </div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label for="toilet_cubicle_available">Number of Cubicle Toilet Available <span style="color:red;">*</span></label><input type="number" id="toilet_cubicle_available" name="toilet_cubicle_available" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_minor_repair">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="toilet_minor_repair" name="toilet_minor_repair" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_major_repair">Number in need of Major Repair <span style="color:red;">*</span></label><input type="number" id="toilet_major_repair" name="toilet_major_repair" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_renovation_required">Renovation Required <span style="color:red;">*</span></label><input type="number" id="toilet_renovation_required" name="toilet_renovation_required" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_additional_required">Number of Additional Cubicle Toilet Required <span style="color:red;">*</span></label><input type="number" id="toilet_additional_required" name="toilet_additional_required" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_cubicle_available_1_2">Number of Cubicle Toilet Available <span style="color:red;">*</span></label><input type="number" id="toilet_cubicle_available_1_2" name="toilet_cubicle_available" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_minor_repair_1_2">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="toilet_minor_repair_1_2" name="toilet_minor_repair" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_major_repair_1_2">Number in need of Major Repair <span style="color:red;">*</span></label><input type="number" id="toilet_major_repair_1_2" name="toilet_major_repair" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_renovation_required_1_2">Renovation Required <span style="color:red;">*</span></label><input type="number" id="toilet_renovation_required_1_2" name="toilet_renovation_required" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_additional_required_1_2">Number of Additional Cubicle Toilet Required <span style="color:red;">*</span></label><input type="number" id="toilet_additional_required_1_2" name="toilet_additional_required" class="form-control" min="0" required=""></div>
                 </div>
                 <div class="form-group">
-                    <label for="toilet_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                    <textarea id="toilet_repair_description" name="toilet_repair_description" class="form-control" rows="2" required=""></textarea>
+                    <label for="toilet_repair_description_1_2">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                    <textarea id="toilet_repair_description_1_2" name="toilet_repair_description" class="form-control" rows="2" required=""></textarea>
                 </div>
 
                 <h4>4. SEPTIC TANK <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <div>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="available" required=""> Available</label>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="not_available" required=""> Not Available</label>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="needs_evacuation" required=""> Needs Evacuation</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_2" value="available" required=""> Available</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_2" value="not_available" required=""> Not Available</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_2" value="needs_evacuation" required=""> Needs Evacuation</label>
                     </div>
                 </div>
 
                 <h4>5. SOURCE OF POTABLE WATER</h4>
                 <div class="form-group">
                     <div>
-                        <label class="checkbox-inline"><input type="checkbox" name="water_source" value="none"> None</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="water_source" value="well"> Well</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="water_source" value="tap_water"> Tap Water</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="water_source" value="borehole"> Borehole</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="water_source_1_2" value="none"> None</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="water_source_1_2" value="well"> Well</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="water_source_1_2" value="tap_water"> Tap Water</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="water_source_1_2" value="borehole"> Borehole</label>
                     </div>
                     <div class="form-group">
-                        <label for="water_recommendations">Recommendations</label>
-                        <textarea id="water_recommendations" name="water_recommendations" class="form-control" rows="2"></textarea>
+                        <label for="water_recommendations_1_2">Recommendations</label>
+                        <textarea id="water_recommendations_1_2" name="water_recommendations" class="form-control" rows="2"></textarea>
                     </div>
                 </div>
 
                 <h4>6. SOURCE OF ELECTRICITY</h4>
                 <div class="form-group">
                     <div>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="none"> None</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn"> PHCN</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator"> Generator</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar"> Solar</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others"> Others</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="none"> None</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="phcn"> PHCN</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="generator"> Generator</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="solar"> Solar</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="others"> Others</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_2" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                     </div>
                     <div class="form-group">
-                        <label for="electricity_additional_info">Additional information e.g., amount involved, etc</label>
-                        <textarea id="electricity_additional_info" name="electricity_additional_info" class="form-control" rows="2"></textarea>
+                        <label for="electricity_additional_info_1_2">Additional information e.g., amount involved, etc</label>
+                        <textarea id="electricity_additional_info_1_2" name="electricity_additional_info" class="form-control" rows="2"></textarea>
                     </div>
                 </div>
 
@@ -1337,16 +1337,16 @@ h4[onclick] {
             <h4 id="sectionAHeader_1.3" style="margin-bottom: 20px; cursor: pointer;" onclick="toggleSection(&#39;sectionAContent_1.3&#39;, &#39;sectionAHeader_1.3&#39;)">Section A: Bio Data 🔽</h4>
             <div id="sectionAContent_1.3" style="display: block;">
                			
-			<div id="silnat_a_ht_bio_data_wrapper" class="conditional-group for-regular_school for-special_school for-home_economics_centre for-mini_resource_centre" style="display: none;">
+			<div id="silnat_a_ht_bio_data_wrapper_1_3" class="conditional-group for-regular_school for-special_school for-home_economics_centre for-mini_resource_centre" style="display: none;">
                 <h4>Head Teacher Bio Data</h4>
                 <div class="form-row">
                     <div class="form-group">
-                        <label for="silnat_a_ht_name">Head Teacher/Manager Name <span style="color:red;">*</span></label>
-                        <input type="text" id="silnat_a_ht_name" name="silnat_a_ht_name" class="form-control" required="">
+                        <label for="silnat_a_ht_name_1_3">Head Teacher/Manager Name <span style="color:red;">*</span></label>
+                        <input type="text" id="silnat_a_ht_name_1_3" name="silnat_a_ht_name" class="form-control" required="">
                     </div>
                     <div class="form-group">
-                        <label for="silnat_a_ht_contact">Contact Number <span style="color:red;">*</span></label>
-                        <input type="tel" id="silnat_a_ht_contact" name="silnat_a_ht_contact" class="form-control" required="">
+                        <label for="silnat_a_ht_contact_1_3">Contact Number <span style="color:red;">*</span></label>
+                        <input type="tel" id="silnat_a_ht_contact_1_3" name="silnat_a_ht_contact" class="form-control" required="">
                     </div>
                 </div>
 				</div>
@@ -1622,40 +1622,40 @@ h4[onclick] {
                 <div class="form-group">
                     <label>Signboard <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="available_good" required=""> Available and in good condition</label>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="available_not_good" required=""> Available but not in good condition</label>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="not_available" required=""> Not Available</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_3" value="available_good" required=""> Available and in good condition</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_3" value="available_not_good" required=""> Available but not in good condition</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_3" value="not_available" required=""> Not Available</label>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Teachers’ Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="teachers_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_available" name="teachers_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="teachers_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_good" name="teachers_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="teachers_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_required" name="teachers_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_available_1_3">Number Available <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_available_1_3" name="teachers_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_good_1_3">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_good_1_3" name="teachers_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_required_1_3">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_required_1_3" name="teachers_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Learners Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="learners_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="learners_available" name="learners_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="learners_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="learners_furniture_good" name="learners_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="learners_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="learners_furniture_required" name="learners_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="learners_furniture_available_1_3">Number Available <span style="color:red;">*</span></label><input type="number" id="learners_furniture_available_1_3" name="learners_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="learners_furniture_good_1_3">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="learners_furniture_good_1_3" name="learners_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="learners_furniture_required_1_3">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="learners_furniture_required_1_3" name="learners_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
               
                 <div class="form-group">
                     <label class="furniture-label">Classroom Condition <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="classroom_available">Number Available <span style="color:red;">*</span></label><input type="number" id="classroom_available" name="classroom_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="classroom_good" name="classroom_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_minor_repair">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="classroom_minor_repair" name="classroom_minor_repair" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_major_repair">Number in need of Major Repair/Renovation <span style="color:red;">*</span></label><input type="number" id="classroom_major_repair" name="classroom_major_repair" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_required">Number of Additional Classroom Required <span style="color:red;">*</span></label><input type="number" id="classroom_required" name="classroom_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_available_1_3">Number Available <span style="color:red;">*</span></label><input type="number" id="classroom_available_1_3" name="classroom_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_good_1_3">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="classroom_good_1_3" name="classroom_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_minor_repair_1_3">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="classroom_minor_repair_1_3" name="classroom_minor_repair" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_major_repair_1_3">Number in need of Major Repair/Renovation <span style="color:red;">*</span></label><input type="number" id="classroom_major_repair_1_3" name="classroom_major_repair" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_required_1_3">Number of Additional Classroom Required <span style="color:red;">*</span></label><input type="number" id="classroom_required_1_3" name="classroom_required" class="form-control" min="0" required=""></div>
                     </div>
                     <div class="form-group">
-                        <label for="classroom_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                        <textarea id="classroom_repair_description" name="classroom_repair_description" class="form-control" rows="2" required=""></textarea>
+                        <label for="classroom_repair_description_1_3">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                        <textarea id="classroom_repair_description_1_3" name="classroom_repair_description" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
@@ -1664,35 +1664,35 @@ h4[onclick] {
                     <label>a. Shared Facility <span style="color:red;">*</span></label>
                     <div>
                         <label>Is the school located within a school Complex? <span style="color:red;">*</span></label>
-                        <label class="radio-inline"><input type="radio" name="shared_facility_1.1" value="yes" required onchange="handleSharedFacilityChange_1_1(this)"> Yes</label>
-                        <label class="radio-inline"><input type="radio" name="shared_facility_1.1" value="no" required onchange="handleSharedFacilityChange_1_1(this)"> No</label>
+                        <label class="radio-inline"><input type="radio" name="shared_facility_1_3" value="yes" required onchange="handleSharedFacilityChange_1_1(this)"> Yes</label>
+                        <label class="radio-inline"><input type="radio" name="shared_facility_1_3" value="no" required onchange="handleSharedFacilityChange_1_1(this)"> No</label>
                     </div>
-                    <div class="form-group" id="shared_facility_schools_wrapper_1_1" style="display: none;">
-                        <label for="shared_facility_schools_1_1">If Yes, Kindly list other Schools within the Complex <span id="shared_facility_schools_asterisk_1_1" style="color:red; display:none;">*</span></label>
-                        <textarea id="shared_facility_schools_1_1" name="shared_facility_schools_1.1" class="form-control" rows="4"></textarea>
+                    <div class="form-group" id="shared_facility_schools_wrapper_1_3" style="display: none;">
+                        <label for="shared_facility_schools_1_3">If Yes, Kindly list other Schools within the Complex <span id="shared_facility_schools_asterisk_1_3" style="color:red; display:none;">*</span></label>
+                        <textarea id="shared_facility_schools_1_3" name="shared_facility_schools_1.1" class="form-control" rows="4"></textarea>
 
                     </div>
                 </div>
                 <div class="form-group">
                     <label>b. Does the school have perimeter fence: <span style="color:red;">*</span></label>
-                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1.1" value="yes" required onchange="handlePerimeterFenceChange_1_1(this)"> Yes</label>
-                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1.1" value="no" required onchange="handlePerimeterFenceChange_1_1(this)"> No</label>
+                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1_3" value="yes" required onchange="handlePerimeterFenceChange_1_1(this)"> Yes</label>
+                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1_3" value="no" required onchange="handlePerimeterFenceChange_1_1(this)"> No</label>
                 </div>
-                <div class="form-group" id="fence_condition_wrapper_1_1" style="display: none;">
-                    <label>If Yes, in what State? <span id="fence_condition_asterisk_1_1" style="color:red; display:none;">*</span></label>
+                <div class="form-group" id="fence_condition_wrapper_1_3" style="display: none;">
+                    <label>If Yes, in what State? <span id="fence_condition_asterisk_1_3" style="color:red; display:none;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="fence_condition_1.1" value="good" onchange="handleFenceConditionChange_1_1(this)"> In Good Condition</label>
-                        <label class="radio-inline"><input type="radio" name="fence_condition_1.1" value="minor_repair" onchange="handleFenceConditionChange_1_1(this)"> Need Minor Repair</label>
-                        <label class="radio-inline"><input type="radio" name="fence_condition_1.1" value="major_repair" onchange="handleFenceConditionChange_1_1(this)"> Need Major Repair</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_3" value="good" onchange="handleFenceConditionChange_1_1(this)"> In Good Condition</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_3" value="minor_repair" onchange="handleFenceConditionChange_1_1(this)"> Need Minor Repair</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_3" value="major_repair" onchange="handleFenceConditionChange_1_1(this)"> Need Major Repair</label>
                     </div>
                 </div>
-                <div class="form-group" id="fence_repair_wrapper_1_1" style="display: none;">
-                    <label for="fence_repair_description_1_1">Briefly, describe the type of repair needed <span id="fence_repair_asterisk_1_1" style="color:red; display:none;">*</span></label>
-                    <textarea id="fence_repair_description_1_1" name="fence_repair_description_1.1" class="form-control" rows="2"></textarea>
+                <div class="form-group" id="fence_repair_wrapper_1_3" style="display: none;">
+                    <label for="fence_repair_description_1_3">Briefly, describe the type of repair needed <span id="fence_repair_asterisk_1_3" style="color:red; display:none;">*</span></label>
+                    <textarea id="fence_repair_description_1_3" name="fence_repair_description_1.1" class="form-control" rows="2"></textarea>
                 </div>
-                <div class="form-group" id="school_perimeter_wrapper_1_1" style="display: none;">
-                    <label for="school_perimeter_1_1">If No, what is the perimeter of the School? <span id="school_perimeter_asterisk_1_1" style="color:red; display:none;">*</span></label>
-                    <input type="text" id="school_perimeter_1_1" name="school_perimeter_1.1" class="form-control">
+                <div class="form-group" id="school_perimeter_wrapper_1_3" style="display: none;">
+                    <label for="school_perimeter_1_3">If No, what is the perimeter of the School? <span id="school_perimeter_asterisk_1_3" style="color:red; display:none;">*</span></label>
+                    <input type="text" id="school_perimeter_1_3" name="school_perimeter_1.1" class="form-control">
 
                 </div>
 
@@ -1700,62 +1700,62 @@ h4[onclick] {
                 <div class="form-group">
                     <label>Type of Toilet: <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="pit" required=""> Pit</label>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="wc" required=""> WC</label>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="squat_water_flush" required=""> Squat Water flush</label>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="none" required=""> None</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_3" value="pit" required=""> Pit</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_3" value="wc" required=""> WC</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_3" value="squat_water_flush" required=""> Squat Water flush</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_3" value="none" required=""> None</label>
                     </div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label for="toilet_cubicle_available">Number of Cubicle Toilet Available <span style="color:red;">*</span></label><input type="number" id="toilet_cubicle_available" name="toilet_cubicle_available" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_minor_repair">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="toilet_minor_repair" name="toilet_minor_repair" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_major_repair">Number in need of Major Repair <span style="color:red;">*</span></label><input type="number" id="toilet_major_repair" name="toilet_major_repair" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_renovation_required">Renovation Required <span style="color:red;">*</span></label><input type="number" id="toilet_renovation_required" name="toilet_renovation_required" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_additional_required">Number of Additional Cubicle Toilet Required <span style="color:red;">*</span></label><input type="number" id="toilet_additional_required" name="toilet_additional_required" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_cubicle_available_1_3">Number of Cubicle Toilet Available <span style="color:red;">*</span></label><input type="number" id="toilet_cubicle_available_1_3" name="toilet_cubicle_available" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_minor_repair_1_3">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="toilet_minor_repair_1_3" name="toilet_minor_repair" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_major_repair_1_3">Number in need of Major Repair <span style="color:red;">*</span></label><input type="number" id="toilet_major_repair_1_3" name="toilet_major_repair" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_renovation_required_1_3">Renovation Required <span style="color:red;">*</span></label><input type="number" id="toilet_renovation_required_1_3" name="toilet_renovation_required" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_additional_required_1_3">Number of Additional Cubicle Toilet Required <span style="color:red;">*</span></label><input type="number" id="toilet_additional_required_1_3" name="toilet_additional_required" class="form-control" min="0" required=""></div>
                 </div>
                 <div class="form-group">
-                    <label for="toilet_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                    <textarea id="toilet_repair_description" name="toilet_repair_description" class="form-control" rows="2" required=""></textarea>
+                    <label for="toilet_repair_description_1_3">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                    <textarea id="toilet_repair_description_1_3" name="toilet_repair_description" class="form-control" rows="2" required=""></textarea>
                 </div>
 
                 <h4>4. SEPTIC TANK <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <div>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="available" required=""> Available</label>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="not_available" required=""> Not Available</label>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="needs_evacuation" required=""> Needs Evacuation</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_3" value="available" required=""> Available</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_3" value="not_available" required=""> Not Available</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_3" value="needs_evacuation" required=""> Needs Evacuation</label>
                     </div>
                 </div>
 
                 <h4>5. SOURCE OF POTABLE WATER <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <div>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="none" required=""> None</label>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="well" required=""> Well</label>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="tap_water" required=""> Tap Water</label>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="borehole" required=""> Borehole</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_3" value="none" required=""> None</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_3" value="well" required=""> Well</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_3" value="tap_water" required=""> Tap Water</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_3" value="borehole" required=""> Borehole</label>
                     </div>
                     <div class="form-group">
-                        <label for="water_recommendations">Recommendations <span style="color:red;">*</span></label>
-                        <textarea id="water_recommendations" name="water_recommendations" class="form-control" rows="2" required=""></textarea>
+                        <label for="water_recommendations_1_3">Recommendations <span style="color:red;">*</span></label>
+                        <textarea id="water_recommendations_1_3" name="water_recommendations" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
                 <h4>6. SOURCE OF ELECTRICITY <span style="color:red;">*</span></h4>
                 <div class="form-group" data-is-required="true">
                     <div>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="none" required=""> None</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="none" required=""> None</label>
 
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn"> PHCN</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator"> Generator</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar"> Solar</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others"> Others</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="phcn"> PHCN</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="generator"> Generator</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="solar"> Solar</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="others"> Others</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_3" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                     </div>
                     <div class="form-group">
-                        <label for="electricity_additional_info">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>
-                        <textarea id="electricity_additional_info" name="electricity_additional_info" class="form-control" rows="2" required=""></textarea>
+                        <label for="electricity_additional_info_1_3">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>
+                        <textarea id="electricity_additional_info_1_3" name="electricity_additional_info" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
@@ -2216,46 +2216,46 @@ h4[onclick] {
                 <h4>Head Teacher Bio Data <span style="color:red;">*</span></h4>
                 <div class="form-row">
                     <div class="form-group">
-                        <label for="silnat_a_ht_name">Head Teacher/Manager Name <span style="color:red;">*</span></label>
-                        <input type="text" id="silnat_a_ht_name" name="silnat_a_ht_name" class="form-control" required="">
+                        <label for="silnat_a_ht_name_1_1">Head Teacher/Manager Name <span style="color:red;">*</span></label>
+                        <input type="text" id="silnat_a_ht_name_1_1" name="silnat_a_ht_name" class="form-control" required="">
                     </div>
 				</div>
                     <div class="form-group">
-                        <label for="silnat_a_ht_contact">Contact Number <span style="color:red;">*</span></label>
-                        <input type="tel" id="silnat_a_ht_contact" name="silnat_a_ht_contact" class="form-control" required="">
+                        <label for="silnat_a_ht_contact_1_1">Contact Number <span style="color:red;">*</span></label>
+                        <input type="tel" id="silnat_a_ht_contact_1_1" name="silnat_a_ht_contact" class="form-control" required="">
                     </div>
                 
                 <div class="form-group">
                     <label>Gender <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_gender" value="male" required=""> Male</label>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_gender" value="female" required=""> Female</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_gender_1_1" value="male" required=""> Male</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_gender_1_1" value="female" required=""> Female</label>
                     </div>
                 </div>
                 <div class="form-group">
                     <label>Marital Status <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status" value="single" required=""> Single</label>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status" value="married" required=""> Married</label>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status" value="divorced" required=""> Divorced</label>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status" value="separated" required=""> Separated</label>
-                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status" value="widow_widower" required=""> Widow/Widower</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status_1_1" value="single" required=""> Single</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status_1_1" value="married" required=""> Married</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status_1_1" value="divorced" required=""> Divorced</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status_1_1" value="separated" required=""> Separated</label>
+                        <label class="radio-inline"><input type="radio" name="silnat_a_ht_marital_status_1_1" value="widow_widower" required=""> Widow/Widower</label>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="silnat_a_ht_highest_qualification">Highest Qualification <span style="color:red;">*</span></label>
-                    <select id="silnat_a_ht_highest_qualification" name="silnat_a_ht_highest_qualification" class="form-control" required="">
+                    <label for="silnat_a_ht_highest_qualification_1_1">Highest Qualification <span style="color:red;">*</span></label>
+                    <select id="silnat_a_ht_highest_qualification_1_1" name="silnat_a_ht_highest_qualification" class="form-control" required="">
                         <option value="">Select Qualification</option>
                         <option value="grade_ii">Grade II</option> <option value="nce">NCE</option> <option value="b_ed">B.Ed</option> <option value="ba_ed">BA. Ed</option> <option value="bsc_ed">B.Sc.Ed</option> <option value="hnd">HND</option> <option value="m_ed">M.Ed</option> <option value="others">Others</option>
                     </select>
                 </div>
                 <div class="form-group conditional-sub-group for-silnat_a_ht_highest_qualification_others" style="display:none;">
-                    <label for="silnat_a_ht_highest_qualification_other">Specify Other Qualification <span style="color:red;">*</span></label>
-                    <input type="text" id="silnat_a_ht_highest_qualification_other" name="silnat_a_ht_highest_qualification_other" class="form-control">
+                    <label for="silnat_a_ht_highest_qualification_other_1_1">Specify Other Qualification <span style="color:red;">*</span></label>
+                    <input type="text" id="silnat_a_ht_highest_qualification_other_1_1" name="silnat_a_ht_highest_qualification_other" class="form-control">
                 </div>
                 <div class="form-group">
-                    <label for="silnat_a_ht_years_experience">Years of Leadership Experience <span style="color:red;">*</span></label>
-                    <select id="silnat_a_ht_years_experience" name="silnat_a_ht_years_experience" class="form-control" required="">
+                    <label for="silnat_a_ht_years_experience_1_1">Years of Leadership Experience <span style="color:red;">*</span></label>
+                    <select id="silnat_a_ht_years_experience_1_1" name="silnat_a_ht_years_experience" class="form-control" required="">
                         <option value="">Select Years</option>
                         <option value="5_below">5 &amp; below</option> <option value="6_10">6-10</option> <option value="11_15">11-15</option> <option value="16_20">16-20</option> <option value="21_above">21 &amp; above</option>
                     </select>
@@ -2565,47 +2565,47 @@ h4[onclick] {
                 <div class="form-group">
                     <label>Signboard <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="available_good" required=""> Available and in good condition</label>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="available_not_good" required=""> Available but not in good condition</label>
-                        <label class="radio-inline"><input type="radio" name="signboard" value="not_available" required=""> Not Available</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_1" value="available_good" required=""> Available and in good condition</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_1" value="available_not_good" required=""> Available but not in good condition</label>
+                        <label class="radio-inline"><input type="radio" name="signboard_1_1" value="not_available" required=""> Not Available</label>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Teachers’ Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="teachers_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_available" name="teachers_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="teachers_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_good" name="teachers_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="teachers_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_required" name="teachers_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_available_1_1">Number Available <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_available_1_1" name="teachers_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_good_1_1">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_good_1_1" name="teachers_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="teachers_furniture_required_1_1">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="teachers_furniture_required_1_1" name="teachers_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">ECCDE Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="eccde_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_available" name="eccde_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="eccde_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_good" name="eccde_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="eccde_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_required" name="eccde_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="eccde_furniture_available_1_1">Number Available <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_available_1_1" name="eccde_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="eccde_furniture_good_1_1">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_good_1_1" name="eccde_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="eccde_furniture_required_1_1">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="eccde_furniture_required_1_1" name="eccde_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Primary Furniture <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="primary_furniture_available">Number Available <span style="color:red;">*</span></label><input type="number" id="primary_furniture_available" name="primary_furniture_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="primary_furniture_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="primary_furniture_good" name="primary_furniture_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="primary_furniture_required">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="primary_furniture_required" name="primary_furniture_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="primary_furniture_available_1_1">Number Available <span style="color:red;">*</span></label><input type="number" id="primary_furniture_available_1_1" name="primary_furniture_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="primary_furniture_good_1_1">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="primary_furniture_good_1_1" name="primary_furniture_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="primary_furniture_required_1_1">Additional Number Required <span style="color:red;">*</span></label><input type="number" id="primary_furniture_required_1_1" name="primary_furniture_required" class="form-control" min="0" required=""></div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="furniture-label">Classroom Condition <span style="color:red;">*</span></label>
                     <div class="form-row">
-                        <div class="form-group"><label for="classroom_available">Number Available <span style="color:red;">*</span></label><input type="number" id="classroom_available" name="classroom_available" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_good">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="classroom_good" name="classroom_good" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_minor_repair">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="classroom_minor_repair" name="classroom_minor_repair" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_major_repair">Number in need of Major Repair/Renovation <span style="color:red;">*</span></label><input type="number" id="classroom_major_repair" name="classroom_major_repair" class="form-control" min="0" required=""></div>
-                        <div class="form-group"><label for="classroom_required">Number of Additional Classroom Required <span style="color:red;">*</span></label><input type="number" id="classroom_required" name="classroom_required" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_available_1_1">Number Available <span style="color:red;">*</span></label><input type="number" id="classroom_available_1_1" name="classroom_available" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_good_1_1">Number in Good Condition <span style="color:red;">*</span></label><input type="number" id="classroom_good_1_1" name="classroom_good" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_minor_repair_1_1">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="classroom_minor_repair_1_1" name="classroom_minor_repair" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_major_repair_1_1">Number in need of Major Repair/Renovation <span style="color:red;">*</span></label><input type="number" id="classroom_major_repair_1_1" name="classroom_major_repair" class="form-control" min="0" required=""></div>
+                        <div class="form-group"><label for="classroom_required_1_1">Number of Additional Classroom Required <span style="color:red;">*</span></label><input type="number" id="classroom_required_1_1" name="classroom_required" class="form-control" min="0" required=""></div>
                     </div>
                     <div class="form-group">
-                        <label for="classroom_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                        <textarea id="classroom_repair_description" name="classroom_repair_description" class="form-control" rows="2" required=""></textarea>
+                        <label for="classroom_repair_description_1_1">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                        <textarea id="classroom_repair_description_1_1" name="classroom_repair_description" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
@@ -2614,96 +2614,96 @@ h4[onclick] {
                     <label>a. Shared Facility <span style="color:red;">*</span></label>
                     <div>
                         <label>Is the school located within a school Complex? <span style="color:red;">*</span></label>
-                        <label class="radio-inline"><input type="radio" name="shared_facility" value="yes" required=""> Yes</label>
-                        <label class="radio-inline"><input type="radio" name="shared_facility" value="no" required=""> No</label>
+                        <label class="radio-inline"><input type="radio" name="shared_facility_1_1" value="yes" required=""> Yes</label>
+                        <label class="radio-inline"><input type="radio" name="shared_facility_1_1" value="no" required=""> No</label>
                     </div>
                     <div class="form-group">
-                        <label for="shared_facility_schools">If Yes, Kindly list other Schools within the Complex <span style="color:red;">*</span></label>
-                        <textarea id="shared_facility_schools" name="shared_facility_schools" class="form-control" rows="4" required=""></textarea>
+                        <label for="shared_facility_schools_1_1">If Yes, Kindly list other Schools within the Complex <span style="color:red;">*</span></label>
+                        <textarea id="shared_facility_schools_1_1" name="shared_facility_schools" class="form-control" rows="4" required=""></textarea>
                     </div>
                 </div>
                 <div class="form-group">
                     <label>b. Does the school have perimeter fence: <span style="color:red;">*</span></label>
-                    <label class="radio-inline"><input type="radio" name="perimeter_fence" value="yes" required=""> Yes</label>
-                    <label class="radio-inline"><input type="radio" name="perimeter_fence" value="no" required=""> No</label>
+                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1_1" value="yes" required=""> Yes</label>
+                    <label class="radio-inline"><input type="radio" name="perimeter_fence_1_1" value="no" required=""> No</label>
                 </div>
                 <div class="form-group">
                     <label>If Yes, in what State? <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="fence_condition" value="good" required=""> In Good Condition</label>
-                        <label class="radio-inline"><input type="radio" name="fence_condition" value="minor_repair" required=""> Need Minor Repair</label>
-                        <label class="radio-inline"><input type="radio" name="fence_condition" value="major_repair" required=""> Need Major Repair</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_1" value="good" required=""> In Good Condition</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_1" value="minor_repair" required=""> Need Minor Repair</label>
+                        <label class="radio-inline"><input type="radio" name="fence_condition_1_1" value="major_repair" required=""> Need Major Repair</label>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="fence_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                    <textarea id="fence_repair_description" name="fence_repair_description" class="form-control" rows="2" required=""></textarea>
+                    <label for="fence_repair_description_1_1">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                    <textarea id="fence_repair_description_1_1" name="fence_repair_description" class="form-control" rows="2" required=""></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="school_perimeter">If No, what is the perimeter of the School? <span style="color:red;">*</span></label>
-                    <input type="text" id="school_perimeter" name="school_perimeter" class="form-control" required="">
+                    <label for="school_perimeter_1_1">If No, what is the perimeter of the School? <span style="color:red;">*</span></label>
+                    <input type="text" id="school_perimeter_1_1" name="school_perimeter" class="form-control" required="">
                 </div>
 
                 <h4>3. TOILET FACILITIES <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <label>Type of Toilet: <span style="color:red;">*</span></label>
                     <div>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="pit" required=""> Pit</label>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="wc" required=""> WC</label>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="squat_water_flush" required=""> Squat Water flush</label>
-                        <label class="radio-inline"><input type="radio" name="toilet_type" value="none" required=""> None</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_1" value="pit" required=""> Pit</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_1" value="wc" required=""> WC</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_1" value="squat_water_flush" required=""> Squat Water flush</label>
+                        <label class="radio-inline"><input type="radio" name="toilet_type_1_1" value="none" required=""> None</label>
                     </div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label for="toilet_cubicle_available">Number of Cubicle Toilet Available <span style="color:red;">*</span></label><input type="number" id="toilet_cubicle_available" name="toilet_cubicle_available" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_minor_repair">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="toilet_minor_repair" name="toilet_minor_repair" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_major_repair">Number in need of Major Repair <span style="color:red;">*</span></label><input type="number" id="toilet_major_repair" name="toilet_major_repair" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_renovation_required">Renovation Required <span style="color:red;">*</span></label><input type="number" id="toilet_renovation_required" name="toilet_renovation_required" class="form-control" min="0" required=""></div>
-                    <div class="form-group"><label for="toilet_additional_required">Number of Additional Cubicle Toilet Required <span style="color:red;">*</span></label><input type="number" id="toilet_additional_required" name="toilet_additional_required" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_cubicle_available_1_1">Number of Cubicle Toilet Available <span style="color:red;">*</span></label><input type="number" id="toilet_cubicle_available_1_1" name="toilet_cubicle_available" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_minor_repair_1_1">Number in need of Minor Repair <span style="color:red;">*</span></label><input type="number" id="toilet_minor_repair_1_1" name="toilet_minor_repair" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_major_repair_1_1">Number in need of Major Repair <span style="color:red;">*</span></label><input type="number" id="toilet_major_repair_1_1" name="toilet_major_repair" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_renovation_required_1_1">Renovation Required <span style="color:red;">*</span></label><input type="number" id="toilet_renovation_required_1_1" name="toilet_renovation_required" class="form-control" min="0" required=""></div>
+                    <div class="form-group"><label for="toilet_additional_required_1_1">Number of Additional Cubicle Toilet Required <span style="color:red;">*</span></label><input type="number" id="toilet_additional_required_1_1" name="toilet_additional_required" class="form-control" min="0" required=""></div>
                 </div>
                 <div class="form-group">
-                    <label for="toilet_repair_description">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
-                    <textarea id="toilet_repair_description" name="toilet_repair_description" class="form-control" rows="2" required=""></textarea>
+                    <label for="toilet_repair_description_1_1">Briefly, describe the type of repair needed <span style="color:red;">*</span></label>
+                    <textarea id="toilet_repair_description_1_1" name="toilet_repair_description" class="form-control" rows="2" required=""></textarea>
                 </div>
 
                 <h4>4. SEPTIC TANK <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <div>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="available" required=""> Available</label>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="not_available" required=""> Not Available</label>
-                        <label class="radio-inline"><input type="radio" name="septic_tank" value="needs_evacuation" required=""> Needs Evacuation</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_1" value="available" required=""> Available</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_1" value="not_available" required=""> Not Available</label>
+                        <label class="radio-inline"><input type="radio" name="septic_tank_1_1" value="needs_evacuation" required=""> Needs Evacuation</label>
                     </div>
                 </div>
 
                 <h4>5. SOURCE OF POTABLE WATER <span style="color:red;">*</span></h4>
                 <div class="form-group">
                     <div>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="none" required=""> None</label>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="well" required=""> Well</label>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="tap_water" required=""> Tap Water</label>
-                        <label class="radio-inline"><input type="radio" name="water_source" value="borehole" required=""> Borehole</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_1" value="none" required=""> None</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_1" value="well" required=""> Well</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_1" value="tap_water" required=""> Tap Water</label>
+                        <label class="radio-inline"><input type="radio" name="water_source_1_1" value="borehole" required=""> Borehole</label>
                     </div>
                     <div class="form-group">
-                        <label for="water_recommendations">Recommendations <span style="color:red;">*</span></label>
-                        <textarea id="water_recommendations" name="water_recommendations" class="form-control" rows="2" required=""></textarea>
+                        <label for="water_recommendations_1_1">Recommendations <span style="color:red;">*</span></label>
+                        <textarea id="water_recommendations_1_1" name="water_recommendations" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
                 <h4>6. SOURCE OF ELECTRICITY <span style="color:red;">*</span></h4>
                 <div class="form-group" data-is-required="true">
                     <div>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="none"> None</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="none"> None</label>
 
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn"> PHCN</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="generator"> Generator</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="solar"> Solar</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="others"> Others</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
-                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="phcn"> PHCN</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="generator"> Generator</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="solar"> Solar</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="others"> Others</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="phcn_disconnected_bills"> PHCN but Disconnected because of accumulated bills</label>
+                        <label class="checkbox-inline"><input type="checkbox" name="electricity_source_1_1" value="phcn_disconnected_meter"> PHCN but Disconnected because of lack of meter</label>
                     </div>
                     <div class="form-group">
-                        <label for="electricity_additional_info">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>
-                        <textarea id="electricity_additional_info" name="electricity_additional_info" class="form-control" rows="2" required=""></textarea>
+                        <label for="electricity_additional_info_1_1">Additional information e.g., amount involved, etc <span style="color:red;">*</span></label>
+                        <textarea id="electricity_additional_info_1_1" name="electricity_additional_info" class="form-control" rows="2" required=""></textarea>
                     </div>
                 </div>
 
@@ -5413,7 +5413,7 @@ function editRecord(id) {
 
 <script>
 // --- Data for Special Schools ---
-let specialSchoolsData = {};
+specialSchoolsData = {};
 
 async function loadSpecialSchoolsDataFromCSV() {
     try {


### PR DESCRIPTION
This commit addresses two issues in the `index.html` file:

1.  A `SyntaxError` caused by the redeclaration of the `specialSchoolsData` variable. This is fixed by removing the `let` keyword from the second declaration, turning it into an assignment.

2.  Duplicate HTML element IDs across different survey forms. This is resolved by appending a unique suffix to each ID and its corresponding `for` attribute, ensuring that all element IDs are unique within the document.