### PR TITLE
feat: Implement success pop-up and redirect for surveys

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,6 +656,38 @@ h4[onclick] {
     z-index: 2;
 }
         }
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.4);
+}
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 400px;
+    border-radius: 10px;
+    text-align: center;
+    position: relative;
+    color: var(--lagos-navy);
+}
+.close-button {
+    color: #aaa;
+    position: absolute;
+    top: 5px;
+    right: 15px;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
     </style>
 </head>
 <body>
@@ -702,6 +734,12 @@ h4[onclick] {
 
                 </div>
 				<button class="btn btn-secondary" style="width:auto;padding:8px 16px;" onclick="logout()">Sign Out</button>
+            </div>
+            <div id="successModal" class="modal">
+                <div class="modal-content">
+                    <span class="close-button" onclick="closeModal()">&times;</span>
+                    <p id="successMessage"></p>
+                </div>
             </div>
             <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:32px;max-width:1000px;margin:0 auto; margin-top: 32px;">
                 <div class="survey-card" onclick="showSurvey(&#39;silnat&#39;)">
@@ -5636,10 +5674,17 @@ async function submitSurvey(event, surveyType) {
                     const queryParams = new URLSearchParams(new FormData(form)).toString();
                     window.location.href = `reports/voices.html?${queryParams}`;
                 } else {
-                    const successMessage = `${surveyType.replace(/_/g, ' ').toUpperCase()} survey submitted successfully!`;
-                    alert(successMessage); // Show a prominent alert
-                    feedback.className = 'feedback-success'; // Apply success class
-                    feedback.textContent = successMessage;
+                    const successMessageText = `${surveyType.replace(/_/g, ' ').toUpperCase()} survey submitted successfully!`;
+                    const successMessageElement = document.getElementById('successMessage');
+                    const modal = document.getElementById('successModal');
+
+                    if (successMessageElement && modal) {
+                        successMessageElement.textContent = successMessageText;
+                        modal.style.display = 'block';
+                    } else {
+                        alert(successMessageText); // Fallback to alert
+                    }
+
                     form.reset();
                     const uploadedFilesDiv = form.querySelector('.uploaded-files');
                     if (uploadedFilesDiv) uploadedFilesDiv.innerHTML = '';
@@ -5658,6 +5703,14 @@ async function submitSurvey(event, surveyType) {
         }
         console.error(`Error submitting ${surveyType} survey:`, e);
     }
+}
+
+function closeModal() {
+    const modal = document.getElementById('successModal');
+    if (modal) {
+        modal.style.display = 'none';
+    }
+    backToLanding();
 }
 
 

--- a/server.log
+++ b/server.log
@@ -1,4 +1,0 @@
-(node:2260) [MONGODB DRIVER] Warning: useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
-(Use `node --trace-warnings ...` to show where the warning was created)
-(node:2260) [MONGODB DRIVER] Warning: useUnifiedTopology is a deprecated option: useUnifiedTopology has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version
-Server is running on port 3000


### PR DESCRIPTION
This commit introduces a success pop-up modal that appears after a user submits any survey. This replaces the previous, less user-friendly `alert()` notification.

Key changes:
- Added a new modal component to `index.html` for displaying the success message.
- Styled the modal using CSS to ensure it is presented as a clean, centered pop-up.
- Modified the `submitSurvey` JavaScript function to show the modal with a dynamic success message upon successful submission.
- Implemented a `closeModal` function that hides the pop-up and redirects the user back to the main landing page, improving the user flow after submission.

All existing backend tests have been run and are passing, ensuring that this change does not introduce any regressions.