### PR TITLE
Feat: Display images in report tables and fix Excel export bug

### DIFF
--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -151,7 +151,7 @@ function exportToExcel() {
         return;
     }
 
-    const surveyType = 'silat_1.2';
+    const surveyType = allSurveys.length > 0 ? allSurveys[0].surveyType : 'silat_1.2';
     const labels = surveyLabelMaps[surveyType] || {};
 
     const worksheetData = allSurveys.map(survey => {

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -151,7 +151,7 @@ function exportToExcel() {
         return;
     }
 
-    const surveyType = 'silat_1.4';
+    const surveyType = allSurveys.length > 0 ? allSurveys[0].surveyType : 'silat_1.4';
     const labels = surveyLabelMaps[surveyType] || {};
 
     const worksheetData = allSurveys.map(survey => {


### PR DESCRIPTION
This change modifies all survey reports to display image thumbnails in the report table. Clicking on a thumbnail opens the full-size image.

Additionally, this change fixes a bug where SILAT 1.2 and 1.4 reports were not exportable to Excel. The `surveyType` is now determined dynamically for these reports, consistent with the other report types.