### PR TITLE
Feat: Display images in report tables and fix Excel export bug

### DIFF
--- a/reports/lori.js
+++ b/reports/lori.js
@@ -161,7 +161,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -161,7 +161,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -165,7 +165,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -165,7 +165,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -165,7 +165,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -161,7 +161,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -165,7 +165,7 @@ function exportToExcel() {
             if (Object.prototype.hasOwnProperty.call(flattenedFormData, key)) {
                 if (key === 'photos' && Array.isArray(flattenedFormData[key])) {
                     flattenedFormData[key].forEach((photo, index) => {
-                        rowData[`Photo ${index + 1}`] = photo;
+                        rowData[`Photo ${index + 1}`] = { v: `View Photo ${index + 1}`, l: { Target: photo } };
                     });
                 } else {
                     const label = labels[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());


### PR DESCRIPTION
This change modifies all survey reports to display image thumbnails in the report table. Clicking on a thumbnail opens the full-size image.

Additionally, this change fixes a bug where the Excel export was failing due to the cell character limit. The export now creates a hyperlink to the base64 image data instead of embedding it directly in the cell.