### PR TITLE
feat: Update LORI survey with new location and remove fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -3068,6 +3068,7 @@ h4[onclick] {
                 <td>
                     <label class="radio-inline"><input type="radio" name="lori_location" value="urban" required=""> Urban</label>
                     <label class="radio-inline"><input type="radio" name="lori_location" value="rural" required=""> Rural</label>
+                    <label class="radio-inline"><input type="radio" name="lori_location" value="riverine" required=""> Riverine</label>
                 </td>
                 <td>School Code from Annual School Census <span style="color:red;">*</span></td>
                 <td><input type="text" name="lori_school_code" class="form-control" required=""></td>
@@ -3288,9 +3289,6 @@ h4[onclick] {
                     <td><input type="radio" name="lori_b_3_j" value="3" required=""></td>
                     <td><input type="radio" name="lori_b_3_j" value="4" required=""></td>
                     <td><input type="radio" name="lori_b_3_j" value="5" required=""></td>
-                    <td><select name="lori_b_3_j_avg" class="form-control" required=""><option value="">Select Score</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option></select></td>
-                    <td><select name="lori_b_3_j_desc" class="form-control" required=""><option value="">Select Descriptor</option><option value="(poor)">(poor)</option><option value="(Fair)">(Fair)</option><option value="(Good)">(Good)</option><option value="(Very Good)">(Very Good)</option><option value="(Excellent)">(Excellent)</option></select></td>
-
                 </tr>
                 <tr>
                     <td rowspan="5">4. Relationship with learners</td>


### PR DESCRIPTION
This commit introduces two changes to the LORI survey:

- Adds a "Riverine" option to the "Location" radio buttons in Section A, providing more accurate location data collection.
- Removes the "Average Score" and "Descriptor" columns from the sub-category "j) New words and concepts are clearly explained and related to learners’ experiences" in Section B, as these fields were deemed unnecessary for this specific item.