### PR TITLE
fix: Correctly locate feedback element in survey submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -5646,7 +5646,7 @@ async function submitSurvey(event, surveyType) {
         console.warn(`Survey type "${surveyType}" is not officially in the allowed list, but proceeding anyway.`);
     }
 
-    const feedback = form.nextElementSibling;
+    const feedback = document.getElementById(`${surveyType}_feedback`);
 
     if (feedback) {
         feedback.textContent = 'Submitting...';


### PR DESCRIPTION
The `submitSurvey` function was using `form.nextElementSibling` to find the feedback element. This did not work for the LORI survey because the feedback div is not a sibling of the form.

This change modifies the `submitSurvey` function to find the feedback element by its ID, which is constructed dynamically using the survey type. This approach is more robust and works for all survey forms, including the LORI survey.