### PR TITLE
feat: Restrict assessor access to reports and logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -773,7 +773,7 @@ h4[onclick] {
                     <p>For Learners</p>
                 </div>
                
-                <div class="survey-card" onclick="window.location.href='/reports'">
+                <div class="survey-card" id="reports-card" onclick="window.location.href='/reports'">
                     <h2>View Survey Reports</h2>
                     <p>Dashboard for all submitted data</p>
                 </div>
@@ -4392,7 +4392,8 @@ function updateUserInfo() {
 function updateAdminLinkState() {
     const adminLink = document.getElementById('admin-link');
     const logCard = document.getElementById('log-card');
-    if (!adminLink || !logCard) return;
+    const reportsCard = document.getElementById('reports-card');
+    if (!adminLink || !logCard || !reportsCard) return;
 
     let user = null;
     try {
@@ -4404,22 +4405,38 @@ function updateAdminLinkState() {
         console.error('Error parsing user from localStorage for admin link state:', e);
     }
 
-    // Login logs card should be visible for any logged-in user
     if (user) {
-        logCard.classList.remove('hidden');
-    } else {
-        logCard.classList.add('hidden');
-    }
+        const userRole = user.role ? user.role.trim().toLowerCase() : '';
 
-    // Admin link for user management is still admin-only
-    if (user && user.role && user.role.trim().toLowerCase() === 'admin') {
-        adminLink.classList.remove('hidden');
-        adminLink.classList.remove('disabled-card');
-        adminLink.onclick = () => { window.location.href = 'admin.html'; };
+        if (userRole === 'admin') {
+            // Admin sees everything
+            logCard.classList.remove('hidden');
+            adminLink.classList.remove('hidden');
+            adminLink.classList.remove('disabled-card');
+            adminLink.onclick = () => { window.location.href = 'admin.html'; };
+            reportsCard.classList.remove('hidden');
+        } else if (userRole === 'assessor') {
+            // Assessor sees neither reports nor logs
+            logCard.classList.add('hidden');
+            adminLink.classList.add('hidden');
+            adminLink.classList.add('disabled-card');
+            adminLink.onclick = null;
+            reportsCard.classList.add('hidden');
+        } else {
+            // Other logged-in users see reports and logs but not admin link
+            logCard.classList.remove('hidden');
+            adminLink.classList.add('hidden');
+            adminLink.classList.add('disabled-card');
+            adminLink.onclick = null;
+            reportsCard.classList.remove('hidden');
+        }
     } else {
+        // Not logged in, hide all protected cards
+        logCard.classList.add('hidden');
         adminLink.classList.add('hidden');
         adminLink.classList.add('disabled-card');
         adminLink.onclick = null;
+        reportsCard.classList.add('hidden');
     }
 }
 


### PR DESCRIPTION
- Added an ID to the 'View Survey Reports' card to allow for role-based access control.
- Updated the 'updateAdminLinkState' function to hide the 'View Survey Reports' and 'User Login Logs' cards for users with the 'assessor' role.