### PR TITLE
perf: exclude large fields from user list endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -231,7 +231,7 @@ app.post('/api/users', protect, admin, async (req, res) => {
 });
 
 app.get('/api/users', protect, admin, async (req, res) => {
-  const users = await User.find({});
+  const users = await User.find({}).select('-password -imageUrl');
   res.json(users);
 });
 


### PR DESCRIPTION
The user management page was slow to load because the API endpoint to fetch users was returning all user data, including potentially large base64-encoded images.

This change modifies the `/api/users` endpoint to exclude the `password` and `imageUrl` fields from the response. This significantly reduces the payload size and improves the loading speed of the user list.