### PR TITLE
feat: Exclude data:image from user CSV export

### DIFF
--- a/server.js
+++ b/server.js
@@ -285,10 +285,19 @@ app.put('/api/users/:id/image', protect, admin, async (req, res) => {
 app.get('/api/users/export', protect, admin, async (req, res) => {
   try {
     const users = await User.find({}).select('-password').lean();
+    // Process users to handle data:image in imageUrl
+    const processedUsers = users.map(user => {
+      if (user.imageUrl && user.imageUrl.startsWith('data:image')) {
+        // Replace base64 image data with a placeholder
+        return { ...user, imageUrl: '[Embedded Image]' };
+      }
+      return user;
+    });
+
     const fields = ['_id', 'username', 'role', 'createdAt', 'imageUrl'];
     const opts = { fields };
     const parser = new Parser(opts);
-    const csv = parser.parse(users);
+    const csv = parser.parse(processedUsers);
     res.header('Content-Type', 'text/csv');
     res.attachment('users.csv');
     res.send(csv);


### PR DESCRIPTION
The user CSV export includes the `imageUrl` field, which can contain long base64-encoded `data:image` strings. This makes the CSV file unnecessarily large and difficult to read.

This change modifies the `/api/users/export` endpoint to process the user data before converting it to CSV. It checks if the `imageUrl` starts with `data:image` and, if so, replaces it with the placeholder `[Embedded Image]`. This keeps the CSV clean while still indicating the presence of an embedded image.