### PR TITLE
Fix: Correct radio button names in SILAT 1.1 form

### DIFF
--- a/index.html
+++ b/index.html
@@ -2659,79 +2659,79 @@ h4[onclick] {
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.2" required=""></td><td><input type="radio" name="discipline_a_1.2" required=""></td></tr>
-                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.2" required=""></td><td><input type="radio" name="discipline_b_1.2" required=""></td></tr>
-                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.2" required=""></td><td><input type="radio" name="discipline_c_1.2" required=""></td></tr>
-                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.2" required=""></td><td><input type="radio" name="discipline_d_1.2" required=""></td></tr>
-                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.2" required=""></td><td><input type="radio" name="discipline_e_1.2" required=""></td></tr>
+                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.1" value="yes" required=""></td><td><input type="radio" name="discipline_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.1" value="yes" required=""></td><td><input type="radio" name="discipline_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.1" value="yes" required=""></td><td><input type="radio" name="discipline_c_1.1" value="no" required=""></td></tr>
+                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.1" value="yes" required=""></td><td><input type="radio" name="discipline_d_1.1" value="no" required=""></td></tr>
+                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.1" value="yes" required=""></td><td><input type="radio" name="discipline_e_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 <h5>Cooperation and Team Work <span style="color:red;">*</span></h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.2" required=""></td><td><input type="radio" name="cooperation_a_1.2" required=""></td></tr>
-                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.2" required=""></td><td><input type="radio" name="cooperation_b_1.2" required=""></td></tr>
-                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.2" required=""></td><td><input type="radio" name="cooperation_c_1.2" required=""></td></tr>
-                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.2" required=""></td><td><input type="radio" name="cooperation_d_1.2" required=""></td></tr>
+                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.1" value="yes" required=""></td><td><input type="radio" name="cooperation_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.1" value="yes" required=""></td><td><input type="radio" name="cooperation_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.1" value="yes" required=""></td><td><input type="radio" name="cooperation_c_1.1" value="no" required=""></td></tr>
+                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.1" value="yes" required=""></td><td><input type="radio" name="cooperation_d_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 <h5>Communication in the School <span style="color:red;">*</span></h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.2" required=""></td><td><input type="radio" name="communication_a_1.2" required=""></td></tr>
-                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.2" required=""></td><td><input type="radio" name="communication_b_1.2" required=""></td></tr>
-                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.2" required=""></td><td><input type="radio" name="communication_c_1.2" required=""></td></tr>
+                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.1" value="yes" required=""></td><td><input type="radio" name="communication_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.1" value="yes" required=""></td><td><input type="radio" name="communication_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.1" value="yes" required=""></td><td><input type="radio" name="communication_c_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 <h5>School and Community Relations <span style="color:red;">*</span></h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.2" required=""></td><td><input type="radio" name="community_a_1.2" required=""></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.2" required=""></td><td><input type="radio" name="community_b_1.2" required=""></td></tr>
-                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.2" required=""></td><td><input type="radio" name="community_c_1.2" required=""></td></tr>
-                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.2" required=""></td><td><input type="radio" name="community_d_1.2" required=""></td></tr>
-                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.2" required=""></td><td><input type="radio" name="community_e_1.2" required=""></td></tr>
+                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.1" value="yes" required=""></td><td><input type="radio" name="community_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.1" value="yes" required=""></td><td><input type="radio" name="community_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.1" value="yes" required=""></td><td><input type="radio" name="community_c_1.1" value="no" required=""></td></tr>
+                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.1" value="yes" required=""></td><td><input type="radio" name="community_d_1.1" value="no" required=""></td></tr>
+                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.1" value="yes" required=""></td><td><input type="radio" name="community_e_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 <h5>Supervision and Monitoring <span style="color:red;">*</span></h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.2" value="yes" required=""></td><td><input type="radio" name="supervision_a_1.2" value="no" required=""></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.2" value="yes" required=""></td><td><input type="radio" name="supervision_b_1.2" value="no" required=""></td></tr>
-                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.2" value="yes" required=""></td><td><input type="radio" name="supervision_c_1.2" value="no" required=""></td></tr>
-						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_d_1.2" value="yes" required=""></td><td><input type="radio" name="supervision_d_1.2" value="no" required=""></td></tr>
-                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_e_1.2" value="yes" required=""></td><td><input type="radio" name="supervision_e_1.2" value="no" required=""></td></tr>
+                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.1" value="yes" required=""></td><td><input type="radio" name="supervision_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.1" value="yes" required=""></td><td><input type="radio" name="supervision_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.1" value="yes" required=""></td><td><input type="radio" name="supervision_c_1.1" value="no" required=""></td></tr>
+						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_d_1.1" value="yes" required=""></td><td><input type="radio" name="supervision_d_1.1" value="no" required=""></td></tr>
+                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_e_1.1" value="yes" required=""></td><td><input type="radio" name="supervision_e_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 <h5>School Records <span style="color:red;">*</span></h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.2" required=""></td><td><input type="radio" name="records_a_1.2" required=""></td></tr>
-                        <tr><td>b.</td><td>Maintenance of daily classroom register by teachers</td><td><input type="radio" name="records_b_1.2" required=""></td><td><input type="radio" name="records_b_1.2" required=""></td></tr>
-                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.2" required=""></td><td><input type="radio" name="records_c_1.2" required=""></td></tr>
-						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_c_1.2" required=""></td><td><input type="radio" name="records_c_1.2" required=""></td></tr>
-                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_d_1.2" required=""></td><td><input type="radio" name="records_d_1.2" required=""></td></tr>
-						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_d_1.2" required=""></td><td><input type="radio" name="records_d_1.2" required=""></td></tr>
-						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_d_1.2" required=""></td><td><input type="radio" name="records_d_1.2" required=""></td></tr>
-						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_d_1.2" required=""></td><td><input type="radio" name="records_d_1.2" required=""></td></tr>
-                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_e_1.2" required=""></td><td><input type="radio" name="records_e_1.2" required=""></td></tr>
+                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.1" value="yes" required=""></td><td><input type="radio" name="records_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Maintenance of daily classroom register by teachers</td><td><input type="radio" name="records_b_1.1" value="yes" required=""></td><td><input type="radio" name="records_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.1" value="yes" required=""></td><td><input type="radio" name="records_c_1.1" value="no" required=""></td></tr>
+						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_d_1.1" value="yes" required=""></td><td><input type="radio" name="records_d_1.1" value="no" required=""></td></tr>
+                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_e_1.1" value="yes" required=""></td><td><input type="radio" name="records_e_1.1" value="no" required=""></td></tr>
+						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_f_1.1" value="yes" required=""></td><td><input type="radio" name="records_f_1.1" value="no" required=""></td></tr>
+						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_g_1.1" value="yes" required=""></td><td><input type="radio" name="records_g_1.1" value="no" required=""></td></tr>
+						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_h_1.1" value="yes" required=""></td><td><input type="radio" name="records_h_1.1" value="no" required=""></td></tr>
+                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_i_1.1" value="yes" required=""></td><td><input type="radio" name="records_i_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 <h5>Health and Hygiene <span style="color:red;">*</span></h5>
                 <table class="data-table" width="100%">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.2" required=""></td><td><input type="radio" name="health_a_1.2" required=""></td></tr>
-                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.2" required=""></td><td><input type="radio" name="health_b_1.2" required=""></td></tr>
-                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.2" required=""></td><td><input type="radio" name="health_c_1.2" required=""></td></tr>
-                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.2" required=""></td><td><input type="radio" name="health_d_1.2" required=""></td></tr>
-                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.2" required=""></td><td><input type="radio" name="health_e_1.2" required=""></td></tr>
-						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_e_1.2" required=""></td><td><input type="radio" name="health_e_1.2" required=""></td></tr>
+                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.1" value="yes" required=""></td><td><input type="radio" name="health_a_1.1" value="no" required=""></td></tr>
+                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.1" value="yes" required=""></td><td><input type="radio" name="health_b_1.1" value="no" required=""></td></tr>
+                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.1" value="yes" required=""></td><td><input type="radio" name="health_c_1.1" value="no" required=""></td></tr>
+                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.1" value="yes" required=""></td><td><input type="radio" name="health_d_1.1" value="no" required=""></td></tr>
+                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.1" value="yes" required=""></td><td><input type="radio" name="health_e_1.1" value="no" required=""></td></tr>
+						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_f_1.1" value="yes" required=""></td><td><input type="radio" name="health_f_1.1" value="no" required=""></td></tr>
                     </tbody>
                 </table>
                 </div>	


### PR DESCRIPTION
The radio buttons in Section C of the SILAT 1.1 survey form had duplicated `name` attributes, causing them to function as a single group instead of independent questions. This was due to a copy-paste error where multiple rows in the "School Records" and "Health and Hygiene" tables used the same `name` attribute.

This change corrects the `name` attributes to be unique for each question, ensuring they work as expected. The `name` attributes have also been updated to use the `_1.1` suffix, consistent with the form's version. Additionally, `value` attributes have been added to the radio buttons for better form data handling.