### PR TITLE
feat: Require assessors to change password on first login

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,10 +694,8 @@ h4[onclick] {
   		
 		  <div class="container">
         <!-- Authentication Screen -->
-        <div id="authScreen" class="auth-container hidden">
+        <div id="authScreen" class="auth-container">
             <h3 class="auth-title">LSUBEB/PIMU NEEDS INSTRUMENT Login</h3>
-            
-            
             <div class="form-group">
                 <label for="username">Username <span style="color:red;">*</span></label>
                 <input type="text" id="username" class="form-control" required="">
@@ -707,6 +705,24 @@ h4[onclick] {
                 <input type="password" id="password" class="form-control" required="">
             </div>
             <button type="button" class="btn" onclick="login()">Login</button>
+        </div>
+
+        <!-- Password Change Modal -->
+        <div id="passwordChangeModal" class="modal" style="display: none;">
+            <div class="modal-content">
+                <h3 class="auth-title">Change Password</h3>
+                <p>You are required to change your password before you can proceed.</p>
+                <div id="password-change-error" class="error-message" style="display: none; color: red;"></div>
+                <div class="form-group">
+                    <label for="new-password">New Password</label>
+                    <input type="password" id="new-password" class="form-control" required="">
+                </div>
+                <div class="form-group">
+                    <label for="confirm-password">Confirm New Password</label>
+                    <input type="password" id="confirm-password" class="form-control" required="">
+                </div>
+                <button type="button" class="btn" onclick="changePassword()">Change Password</button>
+            </div>
         </div>
 
         <!-- Landing Page: Four Survey Cards -->
@@ -4670,26 +4686,31 @@ async function login() {
         console.log('Login response data:', JSON.stringify(data));
 
         if (response.ok) {
-            currentUser = data.username;
-            localStorage.setItem('auditAppCurrentUser', JSON.stringify(data));
-            document.getElementById('authScreen').classList.add('hidden');
-            document.getElementById('landingPage').classList.remove('hidden');
+            if (data.passwordResetRequired) {
+                localStorage.setItem('auditAppCurrentUser', JSON.stringify(data)); // Store user data to get token for password change
+                document.getElementById('passwordChangeModal').style.display = 'block';
+                document.getElementById('authScreen').classList.add('hidden');
+            } else {
+                currentUser = data.username;
+                localStorage.setItem('auditAppCurrentUser', JSON.stringify(data));
+                document.getElementById('authScreen').classList.add('hidden');
+                document.getElementById('landingPage').classList.remove('hidden');
 
-            // Defer UI updates to ensure the DOM is ready
-            setTimeout(() => {
-                updateUserInfo();
-                updateAdminLinkState(); // Update link state after login
-            }, 0);
+                // Defer UI updates to ensure the DOM is ready
+                setTimeout(() => {
+                    updateUserInfo();
+                    updateAdminLinkState(); // Update link state after login
+                }, 0);
 
-            loadLocalGovernments();
-            try {
-                updateDashboard();
-            } catch (e) {
-                console.error('Error in updateDashboard:', e);
+                loadLocalGovernments();
+                try {
+                    updateDashboard();
+                } catch (e) {
+                    console.error('Error in updateDashboard:', e);
+                }
+                loadRecords();
+                updateConnectionStatus();
             }
-            loadRecords();
-            updateConnectionStatus();
-
         } else {
             console.error('Login failed with status:', response.status);
             let msg = document.getElementById('loginErrorMsg');
@@ -4728,6 +4749,66 @@ function logout() {
     
     // Redirect to the login page to ensure a clean state
     window.location.href = 'index.html';
+}
+
+async function changePassword() {
+    const newPassword = document.getElementById('new-password').value;
+    const confirmPassword = document.getElementById('confirm-password').value;
+    const errorDiv = document.getElementById('password-change-error');
+
+    if (newPassword !== confirmPassword) {
+        errorDiv.textContent = 'Passwords do not match.';
+        errorDiv.style.display = 'block';
+        return;
+    }
+
+    // Basic password validation
+    if (newPassword.length < 8) {
+        errorDiv.textContent = 'Password must be at least 8 characters long.';
+        errorDiv.style.display = 'block';
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+
+    try {
+        const response = await fetch('/api/user/password', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${user.token}`
+            },
+            body: JSON.stringify({ password: newPassword }),
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            document.getElementById('passwordChangeModal').style.display = 'none';
+            // Refresh user data in localStorage
+            const updatedUser = { ...user, passwordResetRequired: false };
+            localStorage.setItem('auditAppCurrentUser', JSON.stringify(updatedUser));
+            // Proceed to the landing page
+            document.getElementById('landingPage').classList.remove('hidden');
+            currentUser = updatedUser.username;
+            updateUserInfo();
+            updateAdminLinkState();
+            loadLocalGovernments();
+            try {
+                updateDashboard();
+            } catch (e) {
+                console.error('Error in updateDashboard:', e);
+            }
+            loadRecords();
+            updateConnectionStatus();
+        } else {
+            errorDiv.textContent = data.message || 'An error occurred.';
+            errorDiv.style.display = 'block';
+        }
+    } catch (error) {
+        errorDiv.textContent = 'A network error occurred. Please try again.';
+        errorDiv.style.display = 'block';
+    }
 }
 
         // Navigation

--- a/server.js
+++ b/server.js
@@ -112,6 +112,27 @@ app.post('/api/login', async (req, res) => {
   }
 });
 
+app.put('/api/user/password', protect, async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id);
+
+    if (user) {
+      const passwordError = validatePassword(req.body.password);
+      if (passwordError) {
+        return res.status(400).json({ message: passwordError });
+      }
+      user.password = req.body.password;
+      user.passwordResetRequired = false;
+      await user.save();
+      res.json({ message: 'Password updated successfully' });
+    } else {
+      res.status(404).json({ message: 'User not found' });
+    }
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
 // User Registration endpoint removed as per new requirements.
 // User creation is now handled by admins only via /api/users.
 
@@ -211,6 +232,7 @@ app.post('/api/users', protect, admin, async (req, res) => {
       password,
       role,
       imageUrl,
+      passwordResetRequired: role === 'assessor',
     });
 
     if (user) {


### PR DESCRIPTION
This feature implements a new requirement for all users with the 'assessor' role to change their password upon their initial login.

Key changes include:
- Backend:
  - The user creation endpoint (`POST /api/users`) now sets a `passwordResetRequired` flag to `true` for new assessors.
  - A new secure endpoint (`PUT /api/user/password`) is added to allow authenticated users to change their own password. This action also sets `passwordResetRequired` to `false`.
- Frontend:
  - After a successful login, the application checks the `passwordResetRequired` flag.
  - If the flag is true, a modal dialog is displayed, prompting the user to enter and confirm a new password.
  - The user is prevented from accessing the main application until they have successfully changed their password.
  - Client-side validation is included for the new password form.
  - The `updateDashboard()` function is now called after a successful password change to ensure UI consistency.