### PR TITLE
feat: Add delete functionality to all survey report modules

### DIFF
--- a/reports/lori.html
+++ b/reports/lori.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('lori')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/lori.js
+++ b/reports/lori.js
@@ -61,7 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -72,6 +75,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching LORI reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('silat_1.1')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -72,7 +72,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -83,6 +86,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching SILAT_1.1 reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/reports/silat_1.2.html
+++ b/reports/silat_1.2.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('silat_1.2')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -61,7 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -72,6 +75,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching SILAT_1.2 reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/reports/silat_1.3.html
+++ b/reports/silat_1.3.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('silat_1.3')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -61,7 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -72,6 +75,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching SILAT_1.3 reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/reports/silat_1.4.html
+++ b/reports/silat_1.4.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('silat_1.4')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -61,7 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -72,6 +75,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching SILAT_1.4 reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/reports/style.css
+++ b/reports/style.css
@@ -11,6 +11,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-
 .header .logo { display: flex; align-items: center; font-size: 24px; font-weight: bold; color: var(--lagos-white); }
 .header .logo img { height: 40px; width: 40px; margin-right: 12px; }
 .btn, .btn-secondary { background: var(--lagos-green); border-color: var(--lagos-yellow); color: var(--lagos-white); text-decoration: none; padding: 8px 16px; border-radius: 10px; border: 1px solid transparent; cursor: pointer; }
+.btn-danger { background-color: var(--lagos-red); }
 .content-area { background: var(--lagos-white); border-radius: 15px; padding: 30px; overflow-y: auto; }
 .data-table { width: 100%; border-collapse: collapse; background: var(--lagos-white); border-radius: 10px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); margin-top: 20px; }
 .data-table th, .data-table td { padding: 12px 15px; text-align: left; border-bottom: 1px solid #e5e7eb; }

--- a/reports/tcmats.html
+++ b/reports/tcmats.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('tcmats')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -61,7 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -72,6 +75,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching TCMATS reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/reports/voices.html
+++ b/reports/voices.html
@@ -24,6 +24,7 @@
                 <div id="export-buttons">
                     <button class="btn" onclick="exportToPDF()">Export to PDF</button>
                     <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn btn-danger" onclick="deleteAllReports('voices')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>
             <table class="data-table" id="reportsTable">

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -61,7 +61,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td>${respondentName}</td>
                 <td>${new Date(survey.createdAt).toLocaleString()}</td>
                 <td>${imagesHtml}</td>
-                <td><button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button></td>
+                <td>
+                    <button class="btn" onclick='viewDetails(${JSON.stringify(survey)})'>View Details</button>
+                    <button class="btn btn-danger" onclick="deleteReport('${survey._id}')" style="margin-left: 5px;">Delete</button>
+                </td>
             `;
         });
     })
@@ -72,6 +75,72 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('Error fetching VOICES reports:', error);
     });
 });
+
+function deleteReport(id) {
+    if (!confirm('Are you sure you want to delete this report?')) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete report.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error('Error deleting report:', error);
+    });
+}
+
+function deleteAllReports(surveyType) {
+    if (!confirm(`Are you sure you want to delete all ${surveyType.toUpperCase()} reports? This action cannot be undone.`)) {
+        return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required.');
+        return;
+    }
+
+    fetch(`/api/reports/all/${surveyType}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${user.token}`
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete all reports.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        alert(data.message);
+        location.reload();
+    })
+    .catch(error => {
+        alert(error.message);
+        console.error(`Error deleting all ${surveyType} reports:`, error);
+    });
+}
 
 const modal = document.getElementById('detailsModal');
 const modalData = document.getElementById('modal-data');

--- a/server.js
+++ b/server.js
@@ -468,6 +468,36 @@ app.get('/api/reports/:type', protect, async (req, res) => {
   }
 });
 
+// DELETE endpoint for a single survey report
+app.delete('/api/reports/:id', protect, admin, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const survey = await SurveyResponse.findById(id);
+
+    if (survey) {
+      await survey.deleteOne();
+      res.json({ message: 'Survey report deleted successfully.' });
+    } else {
+      res.status(404).json({ message: 'Survey report not found.' });
+    }
+  } catch (error) {
+    console.error(`Error deleting survey report:`, error);
+    res.status(500).json({ message: 'Failed to delete survey report.', error: error.message });
+  }
+});
+
+// DELETE endpoint for all survey reports of a specific type
+app.delete('/api/reports/all/:type', protect, admin, async (req, res) => {
+  try {
+    const { type } = req.params;
+    const result = await SurveyResponse.deleteMany({ surveyType: type });
+    res.json({ message: `${result.deletedCount} survey reports of type '${type}' deleted successfully.` });
+  } catch (error) {
+    console.error(`Error deleting all survey reports of type ${type}:`, error);
+    res.status(500).json({ message: `Failed to delete survey reports of type ${type}.`, error: error.message });
+  }
+});
+
 // Serve static files from the 'reports' directory
 app.use('/reports', express.static(path.join(__dirname, 'reports')));
 


### PR DESCRIPTION
This commit introduces the functionality to delete individual survey reports and all survey reports of a specific type.

The following changes have been made:
- Added a `DELETE /api/reports/:id` endpoint to `server.js` to delete a single report.
- Added a `DELETE /api/reports/all/:type` endpoint to `server.js` to delete all reports of a given type.
- Both endpoints are protected by admin middleware.
- Added "Delete" and "Delete All" buttons to the UI of all survey report modules.
- Implemented the corresponding JavaScript functions to handle the API calls with confirmation dialogs.
- Added a `.btn-danger` style for the delete buttons.