### PR TITLE
fix: Add authorization token to survey submissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -6044,9 +6044,17 @@ async function submitSurvey(event, surveyType) {
     }
 
     try {
+        const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+        const token = user ? user.token : null;
+
+        const headers = { 'Content-Type': 'application/json' };
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+
         const res = await fetch(`/api/surveys/${surveyType}`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: headers,
             body: JSON.stringify(data)
         });
 


### PR DESCRIPTION
The `submitSurvey` function in `index.html` was not including the authentication token in requests to the backend API. This caused "Not authorized, no token" errors on protected survey submission endpoints.

This change modifies the `submitSurvey` function to:
- Retrieve the user's JWT from `localStorage`.
- Add the `Authorization: Bearer <token>` header to the `fetch` request.

This ensures that all survey submissions are properly authenticated.