### PR TITLE
feat: Implement 20-minute inactivity logout and handle token expiration

### DIFF
--- a/index.html
+++ b/index.html
@@ -4676,12 +4676,21 @@ async function showLogs() {
 
     if (logDisplayArea.classList.contains('hidden')) {
         try {
-            const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+            const userStr = localStorage.getItem('auditAppCurrentUser');
+            if (!userStr) { return; } // Guard clause
+            const user = JSON.parse(userStr);
+            if (!user || !user.token) { return; } // Guard clause
+
             const response = await fetch('/api/logs', {
                 headers: {
                     'Authorization': `Bearer ${user.token}`
                 }
             });
+
+            if (response.status === 401) {
+                logout();
+                return;
+            }
 
             if (response.ok) {
                 const logs = await response.json();
@@ -4840,6 +4849,11 @@ async function changePassword() {
             },
             body: JSON.stringify({ password: newPassword }),
         });
+
+        if (response.status === 401) {
+            logout();
+            return;
+        }
 
         const data = await response.json();
 
@@ -6056,6 +6070,10 @@ async function submitSurvey(event, surveyType) {
                 const successMessage = encodeURIComponent(`${surveyType.replace(/_/g, ' ').toUpperCase()} survey submitted successfully!`);
                 window.location.href = `/?status=success&message=${successMessage}`;
             } else {
+                if (res.status === 401) {
+                    logout(); // Token is invalid/expired, force logout
+                    return;
+                }
                 const err = await res.json();
                 feedback.className = ''; // Reset class
                 feedback.style.color = 'var(--lagos-red)';


### PR DESCRIPTION
This commit introduces a security enhancement that automatically logs users out after 20 minutes of inactivity.

Key changes include:
- The server-side JWT expiration time is set to 20 minutes in `server.js`.
- A client-side inactivity timer is added to `index.html`. It resets on user activity and triggers a logout upon expiration.
- All authenticated API calls (`submitSurvey`, `showLogs`, `changePassword`) now include error handling for `401 Unauthorized` responses. If a token expires during an active session, the user is gracefully logged out instead of seeing an error.
- The logout logic is refactored for robustness, ensuring session data is cleared immediately and redirection works correctly.
- A user-friendly message is displayed on the login screen after an automatic logout.