### PR TITLE
fix(reports): Populate username in survey reports

### DIFF
--- a/server.js
+++ b/server.js
@@ -412,6 +412,7 @@ const flattenSubmissions = (submissions) => {
   // Now, create the flattened data
   submissions.forEach(sub => {
     const flatRow = {
+      'Username': sub.user ? sub.user.username : 'N/A',
       'Survey Type': sub.surveyType,
       'Submission Date': new Date(sub.createdAt).toLocaleString(),
     };
@@ -436,7 +437,7 @@ const flattenSubmissions = (submissions) => {
 // Export to Excel
 app.get('/api/export/excel', protect, async (req, res) => {
   try {
-    const submissions = await SurveyResponse.find({}).lean();
+    const submissions = await SurveyResponse.find({}).populate('user', 'username').lean();
     if (submissions.length === 0) {
       return res.status(404).send('No data to export.');
     }


### PR DESCRIPTION
The username field was not being populated in all survey reports because the user field was not being populated when fetching the survey responses for export.

This commit fixes the issue by:
- Populating the user field with the username when fetching survey responses for the Excel export.
- Updating the flattenSubmissions function to include the username in the exported data.