### PR TITLE
feat: Implement client-side session timeout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -85,9 +85,37 @@
             background-color: var(--lagos-red);
             color: var(--lagos-white);
         }
+        .modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0,0,0,0.4);
+        }
+        .modal-content {
+            background-color: #fefefe;
+            margin: 15% auto;
+            padding: 20px;
+            border: 1px solid #888;
+            width: 80%;
+            max-width: 400px;
+            border-radius: 10px;
+            text-align: center;
+            color: var(--lagos-navy);
+        }
     </style>
 </head>
 <body>
+    <div id="inactivityModal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+            <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
+        </div>
+    </div>
     <div class="container">
         <button class="btn btn-home" onclick="window.location.href='/index.html'">Back to Homepage</button>
         <button class="btn btn-logout" onclick="logout()">Logout</button>
@@ -432,6 +460,17 @@
         });
 
         window.onload = () => fetchUsers(1);
+
+        function performClientSideLogout() {
+            localStorage.removeItem('auditAppCurrentUser');
+            clearInactivityListeners();
+        }
+
+        function logout() {
+            performClientSideLogout();
+            window.location.href = '/index.html';
+        }
     </script>
+    <script src="inactivity.js"></script>
 </body>
 </html>

--- a/inactivity.js
+++ b/inactivity.js
@@ -1,0 +1,68 @@
+// --- Inactivity Logout Logic ---
+let inactivityTimer;
+
+function showInactivityModal() {
+    const modal = document.getElementById('inactivityModal');
+    if (modal) {
+        modal.style.display = 'block';
+    }
+}
+
+function closeInactivityModal() {
+    const modal = document.getElementById('inactivityModal');
+    if (modal) {
+        modal.style.display = 'none';
+    }
+    window.location.href = '/'; // Redirect to login page
+}
+
+function handleInactivityLogout() {
+    performClientSideLogout(); // Log out immediately for security
+    showInactivityModal();     // Then show the modal
+}
+
+function resetInactivityTimer() {
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(handleInactivityLogout, 3600000); // 1 hour
+}
+
+function setupInactivityListeners() {
+    // Reset timer on user activity
+    window.addEventListener('mousemove', resetInactivityTimer);
+    window.addEventListener('mousedown', resetInactivityTimer);
+    window.addEventListener('keypress', resetInactivityTimer);
+    window.addEventListener('scroll', resetInactivityTimer);
+    window.addEventListener('touchstart', resetInactivityTimer);
+
+    // Start the timer for the first time
+    resetInactivityTimer();
+}
+
+function clearInactivityListeners() {
+    clearTimeout(inactivityTimer);
+    window.removeEventListener('mousemove', resetInactivityTimer);
+    window.removeEventListener('mousedown', resetInactivityTimer);
+    window.removeEventListener('keypress', resetInactivityTimer);
+    window.removeEventListener('scroll', resetInactivityTimer);
+    window.removeEventListener('touchstart', resetInactivityTimer);
+}
+
+// It's assumed that performClientSideLogout is defined in the main script of each page.
+// If not, it should be included here or in another shared script.
+// For example:
+/*
+function performClientSideLogout() {
+    // This function might need access to `currentUser` or other page-specific variables.
+    // If it's generic enough, it can be fully defined here.
+    // For now, we assume it exists on the pages that include this script.
+    console.log("Performing client-side logout due to inactivity.");
+    localStorage.removeItem('auditAppCurrentUser');
+    // Any other cleanup...
+}
+*/
+
+// Automatically start listening for inactivity when this script is loaded
+// and a user session exists.
+if (localStorage.getItem('auditAppCurrentUser')) {
+    setupInactivityListeners();
+}

--- a/index.html
+++ b/index.html
@@ -4262,6 +4262,7 @@ select.form-control option {
 
     </style>
     <script src="dropdown.js"></script>
+    <script src="inactivity.js"></script>
     <script>
     // Navigation logic for landing/surveys
     async function showSurvey(survey) {
@@ -4331,55 +4332,6 @@ select.form-control option {
         let isOnline = navigator.onLine;
         let forceOffline = false;
 
-// --- Inactivity Logout Logic ---
-let inactivityTimer;
-
-function showInactivityModal() {
-    const modal = document.getElementById('inactivityModal');
-    if (modal) {
-        modal.style.display = 'block';
-    }
-}
-
-function closeInactivityModal() {
-    const modal = document.getElementById('inactivityModal');
-    if (modal) {
-        modal.style.display = 'none';
-    }
-    window.location.href = '/'; // Redirect to login page
-}
-
-function handleInactivityLogout() {
-    performClientSideLogout(); // Log out immediately for security
-    showInactivityModal();     // Then show the modal
-}
-
-function resetInactivityTimer() {
-    clearTimeout(inactivityTimer);
-    inactivityTimer = setTimeout(handleInactivityLogout, 3600000); // 1 hour
-}
-
-function setupInactivityListeners() {
-    // Reset timer on user activity
-    window.addEventListener('mousemove', resetInactivityTimer);
-    window.addEventListener('mousedown', resetInactivityTimer);
-    window.addEventListener('keypress', resetInactivityTimer);
-    window.addEventListener('scroll', resetInactivityTimer);
-    window.addEventListener('touchstart', resetInactivityTimer);
-
-    // Start the timer for the first time
-    resetInactivityTimer();
-}
-
-function clearInactivityListeners() {
-    clearTimeout(inactivityTimer);
-    window.removeEventListener('mousemove', resetInactivityTimer);
-    window.removeEventListener('mousedown', resetInactivityTimer);
-    window.removeEventListener('keypress', resetInactivityTimer);
-    window.removeEventListener('scroll', resetInactivityTimer);
-    window.removeEventListener('touchstart', resetInactivityTimer);
-}
-        
 // Combined window.onload function
 window.onload = async function() {
     const urlParams = new URLSearchParams(window.location.search);

--- a/login_logs.html
+++ b/login_logs.html
@@ -25,9 +25,17 @@
         .data-table tr:nth-child(even) { background-color: #f8f9fa; }
         .data-table tr:hover { background-color: #e9ecef; }
         #loadingLogsMessage { text-align: center; padding: 20px; font-size: 1.2em; color: var(--lagos-navy); }
+        .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 400px; border-radius: 10px; text-align: center; color: var(--lagos-navy); }
     </style>
 </head>
 <body>
+    <div id="inactivityModal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+            <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
+        </div>
+    </div>
     <div class="container">
         <div class="header">
             <div class="logo">
@@ -58,6 +66,16 @@
         document.addEventListener('DOMContentLoaded', function() {
             fetchLoginLogs();
         });
+
+        function performClientSideLogout() {
+            localStorage.removeItem('auditAppCurrentUser');
+            clearInactivityListeners();
+        }
+
+        function logout() {
+            performClientSideLogout();
+            window.location.href = '/index.html';
+        }
 
         async function fetchLoginLogs() {
             const tableBody = document.querySelector('#loginLogsTable tbody');
@@ -110,5 +128,6 @@
             }
         }
     </script>
+    <script src="inactivity.js"></script>
 </body>
 </html>

--- a/reports.html
+++ b/reports.html
@@ -10,10 +10,19 @@
         table { border-collapse: collapse; width: 100%; }
         th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
         th { background-color: #f2f2f2; }
+        .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 400px; border-radius: 10px; text-align: center; color: var(--lagos-navy); }
     </style>
 </head>
 <body>
+    <div id="inactivityModal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+            <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
+        </div>
+    </div>
     <h1>Survey Reports</h1>
+    <a href="index.html" class="btn-secondary">Back to Home</a>
     <div id="controls">
         <label for="surveyType">Select Survey Type:</label>
         <select id="surveyType">
@@ -30,6 +39,16 @@
     </div>
 
     <script>
+        function performClientSideLogout() {
+            localStorage.removeItem('auditAppCurrentUser');
+            clearInactivityListeners();
+        }
+
+        function logout() {
+            performClientSideLogout();
+            window.location.href = '/index.html';
+        }
+
         async function fetchReport() {
             const surveyType = document.getElementById('surveyType').value;
             if (!surveyType) {
@@ -125,5 +144,6 @@
             reportDataDiv.innerHTML = tableHtml;
         }
     </script>
+    <script src="inactivity.js"></script>
 </body>
 </html>

--- a/reports/index.html
+++ b/reports/index.html
@@ -23,9 +23,17 @@
         .dashboard-card { background: #f8f9fa; border: 1px solid #e9ecef; border-radius: 10px; padding: 20px; text-align: center; box-shadow: 0 4px 6px rgba(0,0,0,0.05); transition: transform 0.2s; }
         .dashboard-card:hover { transform: translateY(-5px); }
         .dashboard-card h3 { margin-bottom: 15px; color: var(--lagos-navy); }
+        .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 400px; border-radius: 10px; text-align: center; color: var(--lagos-navy); }
     </style>
 </head>
 <body>
+    <div id="inactivityModal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+            <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
+        </div>
+    </div>
     <div class="container">
         <div class="header">
             <div class="logo">
@@ -58,6 +66,17 @@
                 dashboard.appendChild(card);
             });
         });
+
+        function performClientSideLogout() {
+            localStorage.removeItem('auditAppCurrentUser');
+            clearInactivityListeners();
+        }
+
+        function logout() {
+            performClientSideLogout();
+            window.location.href = '/index.html';
+        }
     </script>
+    <script src="/inactivity.js"></script>
 </body>
 </html>

--- a/submission_logs.html
+++ b/submission_logs.html
@@ -29,9 +29,17 @@
         .modal-content { background-color: #fefefe; margin: 5% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 700px; border-radius: 15px; }
         .close { color: #aaa; float: right; font-size: 28px; font-weight: bold; }
         .close:hover, .close:focus { color: black; text-decoration: none; cursor: pointer; }
+        .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 400px; border-radius: 10px; text-align: center; color: var(--lagos-navy); }
     </style>
 </head>
 <body>
+    <div id="inactivityModal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+            <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
+        </div>
+    </div>
     <div class="container">
         <div class="header">
             <div class="logo">
@@ -73,6 +81,16 @@
     <script>
         // Global variable to hold submission data
         let allSubmissions = [];
+
+        function performClientSideLogout() {
+            localStorage.removeItem('auditAppCurrentUser');
+            clearInactivityListeners();
+        }
+
+        function logout() {
+            performClientSideLogout();
+            window.location.href = '/index.html';
+        }
 
         document.addEventListener('DOMContentLoaded', function() {
             fetchSubmissions();
@@ -221,5 +239,6 @@
             modal.style.display = "block";
         }
     </script>
+    <script src="inactivity.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a session timeout feature that logs out users after one hour of inactivity.

- A new `inactivity.js` script has been created to handle the session timeout logic. This script sets a one-hour timer that is reset by user activity.
- The `inactivity.js` script has been included in all authenticated pages (`index.html`, `admin.html`, `login_logs.html`, `submission_logs.html`, `reports.html`, and `reports/index.html`).
- An inactivity modal has been added to these pages to notify the user when they are logged out.
- The `logout` function has been updated in these pages to work with the new inactivity script.