### PR TITLE
Fix layout of SILNAT 1.2 survey form

### DIFF
--- a/index.html
+++ b/index.html
@@ -1025,8 +1025,8 @@ h4[onclick] {
                         <label class="checkbox-inline"><input type="checkbox" name="silat_1_2_multigrade_reasons" value="inadequate_teaching_staff"> Inadequate Teaching Staff</label>
                     </div>
                 </div>
-
-                <h5>Assessment of Learners Completion Rate</h5>
+                <div class="form-group">
+                    <h5>Assessment of Learners Completion Rate</h5>
                 <table class="data-table" width="100%">
                     <thead>
                         <tr>
@@ -1082,6 +1082,7 @@ h4[onclick] {
                         </tr>
                     </tbody>
                 </table>
+                </div>
              </div>
 		 </div>							
              


### PR DESCRIPTION
The "Assessment of Learners Completion Rate" section was not semantically grouped with the preceding form elements. This change wraps the section in a `div` with class `form-group` to improve the structure and layout consistency of the form.