### PR TITLE
Fix: Adjust layout of SILAT 1.2 Assessment section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1024,8 +1024,10 @@ h4[onclick] {
 
                         <label class="checkbox-inline"><input type="checkbox" name="silat_1_2_multigrade_reasons" value="inadequate_teaching_staff"> Inadequate Teaching Staff</label>
                     </div>
+                </div>
 
-                    <h5 style="margin-top: 20px;">Assessment of Learners Completion Rate</h5>
+                <div class="form-group form-row full">
+                    <h5>Assessment of Learners Completion Rate</h5>
                     <table class="data-table" width="100%">
                         <thead>
                             <tr>
@@ -1081,7 +1083,6 @@ h4[onclick] {
                             </tr>
                         </tbody>
                     </table>
-
                 </div>
              </div>
 		 </div>							


### PR DESCRIPTION
This commit addresses a layout issue in the SILAT 1.2 survey form. The "Assessment of Learners Completion Rate" section has been moved to be directly under the "Reason(s) for operating the classes as Multigrade" section.

The section has also been wrapped in a `div` with the classes `form-group`, `form-row`, and `full` to ensure it is displayed at full width, as requested by the user.