### PR TITLE
feat: Change vocation text input to dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -1562,7 +1562,13 @@ h4[onclick] {
                 <!-- Types of Vocation Taught -->
                 <div class="form-group">
                     <label for="silat13_vocation_type">Types of Vocation Taught at the centre (Please specify) <span style="color:red;">*</span></label>
-                    <input type="text" id="silat13_vocation_type" name="silat13_vocation_type" class="form-control" required="">
+                    <select id="silat13_vocation_type" name="silat13_vocation_type" class="form-control" required="">
+                        <option value="">Select Vocation Type</option>
+                        <option value="ARTS & CRAFT">ARTS & CRAFT</option>
+                        <option value="HOME ECONOMICS">HOME ECONOMICS</option>
+                        <option value="COMPUTER CENTRE">COMPUTER CENTRE</option>
+                        <option value="MINI RESOURCE">MINI RESOURCE</option>
+                    </select>
                 </div>
 
                 <!-- Number of Instructors -->


### PR DESCRIPTION
Replaced the text input field for 'Types of Vocation Taught at the centre' with a dropdown menu in the SILNAT 1.3 survey form. The dropdown now includes the specified options: ARTS & CRAFT, HOME ECONOMICS, COMPUTER CENTRE, and MINI RESOURCE.