### PR TITLE
feat: Update inactivity logout timeout to 3 hours

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -112,7 +112,7 @@
 <body>
     <div id="inactivityModal" class="modal" style="display: none;">
         <div class="modal-content">
-            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+            <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 3 hours of inactivity.</p>
             <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
         </div>
     </div>

--- a/inactivity.js
+++ b/inactivity.js
@@ -23,7 +23,7 @@ function handleInactivityLogout() {
 
 function resetInactivityTimer() {
     clearTimeout(inactivityTimer);
-    inactivityTimer = setTimeout(handleInactivityLogout, 3600000); // 1 hour
+    inactivityTimer = setTimeout(handleInactivityLogout, 10800000); // 3 hours
 }
 
 function setupInactivityListeners() {

--- a/index.html
+++ b/index.html
@@ -728,7 +728,7 @@ h4[onclick] {
         <!-- Inactivity Modal -->
         <div id="inactivityModal" class="modal" style="display: none;">
             <div class="modal-content">
-                <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 1 hour of inactivity.</p>
+                <p style="margin-bottom: 20px; font-size: 1.1rem;">You have been logged out due to 3 hours of inactivity.</p>
                 <button type="button" class="btn" style="width:auto; padding:10px 30px;" onclick="closeInactivityModal()">OK</button>
             </div>
         </div>

--- a/server.js
+++ b/server.js
@@ -85,7 +85,7 @@ mongoose.connection.once('open', () => {
 
 const generateToken = (id, role) => {
   return jwt.sign({ id, role }, process.env.JWT_SECRET || 'a-very-secret-key', {
-    expiresIn: '1h',
+    expiresIn: '3h',
   });
 };
 


### PR DESCRIPTION
This commit updates the user inactivity logout timeout from 1 hour to 3 hours.

The following changes were made:
- The JWT token expiration in `server.js` was updated to '3h'.
- The client-side inactivity timer in `inactivity.js` was updated to 10800000 milliseconds (3 hours).
- The inactivity logout message in `index.html` and `admin.html` was updated to reflect the new 3-hour timeout.

This ensures that both the server-side session and the client-side inactivity timer are aligned, and the user is correctly informed about the updated timeout period.