### PR TITLE
fix: Display respondent name in silat 1.4 report

### DIFF
--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -3,7 +3,7 @@ let allSurveys = []; // Global variable to hold survey data for exports
 function getSurveyDisplayData(survey) {
     const formData = survey.formData || {};
     const schoolName = formData.silat_1_4_schoolName || 'N/A';
-    const respondentName = 'N/A'; // LGEA-level survey
+    const respondentName = formData.silat_1_4_es_name || 'N/A'; // LGEA-level survey
     const lga = formData.silat_1_4_localGov || 'N/A';
     return { schoolName, respondentName, lga };
 }


### PR DESCRIPTION
The respondent name in the silat 1.4 report was hardcoded to 'N/A'. This change modifies the `getSurveyDisplayData` function in `reports/silat_1.4.js` to correctly display the respondent's name from the `silat_1_4_es_name` field in the form data.