### PR TITLE
feat: Implement 5-hour inactivity timeout

### DIFF
--- a/inactivity.js
+++ b/inactivity.js
@@ -4,7 +4,7 @@ let inactivityTimer;
 function resetInactivityTimer() {
     clearTimeout(inactivityTimer);
     // Directly call the global logout function with a message
-    inactivityTimer = setTimeout(() => logout('You have been logged out due to 3 hours of inactivity.'), 10800000); // 3 hours
+    inactivityTimer = setTimeout(() => logout('You have been logged out due to 5 hours of inactivity.'), 18000000); // 5 hours
 }
 
 function setupInactivityListeners() {

--- a/server.js
+++ b/server.js
@@ -85,7 +85,7 @@ mongoose.connection.once('open', () => {
 
 const generateToken = (id, role) => {
   return jwt.sign({ id, role }, process.env.JWT_SECRET || 'a-very-secret-key', {
-    expiresIn: '3h',
+    expiresIn: '5h',
   });
 };
 


### PR DESCRIPTION
This commit implements a 5-hour inactivity timeout for users.

- Updates the client-side inactivity timer in `inactivity.js` to 5 hours and adjusts the logout message accordingly.
- Updates the server-side JWT expiration in `server.js` to 5 hours to align with the client-side timeout.