### PR TITLE
fix: Sanitize surveyType to prevent newlines in MongoDB namespaces

### DIFF
--- a/server.js
+++ b/server.js
@@ -180,7 +180,11 @@ app.put('/api/user/password', protect, async (req, res) => {
 // Generic endpoint for all surveys
 app.post('/api/surveys/:type', protect, async (req, res) => {
   try {
-    const surveyType = req.params.type;
+    let surveyType = req.params.type;
+    // Sanitize surveyType to remove newlines
+    if (surveyType) {
+      surveyType = surveyType.replace(/(\r\n|\n|\r)/gm, "");
+    }
     console.log(`[${new Date().toISOString()}] Received submission for survey type: ${surveyType}`);
     console.log(`[${new Date().toISOString()}] Request Body:`, JSON.stringify(req.body, null, 2));
 


### PR DESCRIPTION
The silat 1.1 reports were failing to load due to an issue with `mongorestore` silently ignoring namespaces containing newlines. This was caused by newline characters being introduced into the `surveyType` parameter, which is used to construct the MongoDB collection name.

This commit fixes the issue by sanitizing the `surveyType` parameter on the backend to remove any newline characters before it is used. This will prevent future data corruption.

Note: This fix does not clean up any existing corrupted data in the database. The user will need to manually clean the database to fix any existing reports that are failing to load.