### PR TITLE
feat: Add pagination to survey reports

### DIFF
--- a/reports.html
+++ b/reports.html
@@ -12,6 +12,8 @@
         th { background-color: #f2f2f2; }
         .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
         .modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 400px; border-radius: 10px; text-align: center; color: var(--lagos-navy); }
+        #paginationControls { margin-top: 20px; text-align: center; }
+        #paginationControls button { margin: 0 5px; padding: 8px 16px; }
     </style>
 </head>
 <body>
@@ -25,20 +27,23 @@
     <a href="index.html" class="btn-secondary">Back to Home</a>
     <div id="controls">
         <label for="surveyType">Select Survey Type:</label>
-        <select id="surveyType">
+        <select id="surveyType" onchange="fetchReport(1)">
             <option value="">--Select--</option>
             <option value="silnat">SILNAT</option>
             <option value="tcmats">TCMATS</option>
             <option value="lori">LORI</option>
             <option value="voices">VOICES</option>
         </select>
-        <button onclick="fetchReport()">Fetch Report</button>
+        <button onclick="fetchReport(1)">Fetch Report</button>
     </div>
     <div id="reportData">
         <p>Please select a survey type and click "Fetch Report".</p>
     </div>
+    <div id="paginationControls"></div>
 
     <script>
+        let currentPage = 1;
+
         function performClientSideLogout() {
             localStorage.removeItem('auditAppCurrentUser');
             clearInactivityListeners();
@@ -49,31 +54,34 @@
             window.location.href = '/index.html';
         }
 
-        async function fetchReport() {
+        async function fetchReport(page = 1) {
             const surveyType = document.getElementById('surveyType').value;
             if (!surveyType) {
                 alert('Please select a survey type.');
                 return;
             }
 
+            currentPage = page;
             const reportDataDiv = document.getElementById('reportData');
             reportDataDiv.innerHTML = '<p>Loading...</p>';
+            document.getElementById('paginationControls').innerHTML = '';
+
 
             try {
-                const response = await fetch(`/api/reports/${surveyType}`);
+                const response = await fetch(`/api/reports/${surveyType}?page=${page}&limit=20`);
                 if (!response.ok) {
                     const err = await response.json();
                     throw new Error(err.message || `HTTP error! status: ${response.status}`);
                 }
 
                 const data = await response.json();
-                renderReport(data, surveyType);
+                renderReport(data.responses, surveyType, data.pagination);
             } catch (error) {
                 reportDataDiv.innerHTML = `<p style="color: red;">Error: ${error.message}</p>`;
             }
         }
 
-        function renderReport(responses, surveyType) {
+        function renderReport(responses, surveyType, pagination) {
             const reportDataDiv = document.getElementById('reportData');
             if (!responses || responses.length === 0) {
                 reportDataDiv.innerHTML = `<p>No reports found for ${surveyType.toUpperCase()}.</p>`;
@@ -100,7 +108,7 @@
 
             const sortedKeys = Array.from(allFormDataKeys).sort();
 
-            let tableHtml = `<h2>${surveyType.toUpperCase()} Report (${responses.length} responses)</h2>`;
+            let tableHtml = `<h2>${surveyType.toUpperCase()} Report (${pagination.totalResponses} responses)</h2>`;
             tableHtml += '<table><thead><tr>';
             tableHtml += `<th>Survey Type</th><th>Submission Date</th>`;
 
@@ -142,6 +150,21 @@
             tableHtml += '</tbody></table>';
 
             reportDataDiv.innerHTML = tableHtml;
+            renderPagination(pagination);
+        }
+
+        function renderPagination(pagination) {
+            const { currentPage, totalPages } = pagination;
+            const paginationControls = document.getElementById('paginationControls');
+            let paginationHtml = '';
+
+            if (totalPages > 1) {
+                paginationHtml += `<button onclick="fetchReport(${currentPage - 1})" ${currentPage === 1 ? 'disabled' : ''}>Previous</button>`;
+                paginationHtml += `<span> Page ${currentPage} of ${totalPages} </span>`;
+                paginationHtml += `<button onclick="fetchReport(${currentPage + 1})" ${currentPage === totalPages ? 'disabled' : ''}>Next</button>`;
+            }
+
+            paginationControls.innerHTML = paginationHtml;
         }
     </script>
     <script src="inactivity.js"></script>


### PR DESCRIPTION
Implement pagination for the survey reports page to improve performance and reduce memory usage.

- The backend now accepts page and limit parameters to send paginated data.
- The frontend is updated with pagination controls to navigate through the report pages.