### PR TITLE
fix(reports): Correctly parse paginated API response

### DIFF
--- a/reports/lori.js
+++ b/reports/lori.js
@@ -33,7 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -44,7 +44,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -33,7 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -33,7 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -33,7 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -33,7 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -32,7 +32,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return response.json();
     })
-    .then(surveys => {
+    .then(data => {
+        const surveys = data.responses;
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {


### PR DESCRIPTION
The reports were not displaying any inputs because the frontend JavaScript was expecting an array of surveys, but the backend was returning a paginated response with the surveys in a 'responses' property.

This change updates the frontend JavaScript for all report types to correctly parse the paginated response and extract the survey data from the `responses` property.