### PR TITLE
feat(reports): Add pagination controls to report pages

### DIFF
--- a/reports/generic_template.html
+++ b/reports/generic_template.html
@@ -41,6 +41,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/lori.html
+++ b/reports/lori.html
@@ -43,6 +43,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -43,6 +43,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -20,6 +20,10 @@ function getSurveyDisplayData(survey) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAndDisplayReports('silat_1.1');
+});
+
+function fetchAndDisplayReports(surveyType, page = 1) {
     const tableBody = document.querySelector('#reportsTable tbody');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
@@ -29,7 +33,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.1', {
+    loadingMessage.style.display = 'block';
+    tableBody.innerHTML = '';
+
+    fetch(`/api/reports/${surveyType}?page=${page}`, {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -49,11 +56,9 @@ document.addEventListener('DOMContentLoaded', function() {
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.1 reports found.</td></tr>';
+            tableBody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding: 20px;">No ${surveyType.replace(/_/g, ' ').toUpperCase()} reports found.</td></tr>`;
             return;
         }
-
-        tableBody.innerHTML = ''; // Clear previous content
 
         surveys.forEach(survey => {
             const row = tableBody.insertRow();
@@ -81,14 +86,44 @@ document.addEventListener('DOMContentLoaded', function() {
                 </td>
             `;
         });
+
+        renderPagination(data.pagination, surveyType);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
             loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.1 reports:', error);
+        console.error(`Error fetching ${surveyType} reports:`, error);
     });
-});
+}
+
+function renderPagination(pagination, surveyType) {
+    const { currentPage, totalPages } = pagination;
+    const paginationContainer = document.getElementById('pagination-container');
+    paginationContainer.innerHTML = '';
+
+    if (totalPages <= 1) return;
+
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&laquo; Previous';
+    prevButton.className = 'btn';
+    prevButton.disabled = currentPage === 1;
+    prevButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage - 1);
+    paginationContainer.appendChild(prevButton);
+
+    const pageInfo = document.createElement('span');
+    pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+    pageInfo.style.margin = '0 10px';
+    paginationContainer.appendChild(pageInfo);
+
+    const nextButton = document.createElement('button');
+    nextButton.innerHTML = 'Next &raquo;';
+    nextButton.className = 'btn';
+    nextButton.disabled = currentPage === totalPages;
+    nextButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage + 1);
+    paginationContainer.appendChild(nextButton);
+}
+
 
 function deleteReport(id) {
     if (!confirm('Are you sure you want to delete this report?')) {

--- a/reports/silat_1.2.html
+++ b/reports/silat_1.2.html
@@ -43,6 +43,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -9,6 +9,10 @@ function getSurveyDisplayData(survey) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAndDisplayReports('silat_1.2');
+});
+
+function fetchAndDisplayReports(surveyType, page = 1) {
     const tableBody = document.querySelector('#reportsTable tbody');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
@@ -18,7 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.2', {
+    loadingMessage.style.display = 'block';
+    tableBody.innerHTML = '';
+
+    fetch(`/api/reports/${surveyType}?page=${page}`, {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -38,11 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.2 reports found.</td></tr>';
+            tableBody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding: 20px;">No ${surveyType.replace(/_/g, ' ').toUpperCase()} reports found.</td></tr>`;
             return;
         }
-
-        tableBody.innerHTML = ''; // Clear previous content
 
         surveys.forEach(survey => {
             const row = tableBody.insertRow();
@@ -70,14 +75,44 @@ document.addEventListener('DOMContentLoaded', function() {
                 </td>
             `;
         });
+
+        renderPagination(data.pagination, surveyType);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
             loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.2 reports:', error);
+        console.error(`Error fetching ${surveyType} reports:`, error);
     });
-});
+}
+
+function renderPagination(pagination, surveyType) {
+    const { currentPage, totalPages } = pagination;
+    const paginationContainer = document.getElementById('pagination-container');
+    paginationContainer.innerHTML = '';
+
+    if (totalPages <= 1) return;
+
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&laquo; Previous';
+    prevButton.className = 'btn';
+    prevButton.disabled = currentPage === 1;
+    prevButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage - 1);
+    paginationContainer.appendChild(prevButton);
+
+    const pageInfo = document.createElement('span');
+    pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+    pageInfo.style.margin = '0 10px';
+    paginationContainer.appendChild(pageInfo);
+
+    const nextButton = document.createElement('button');
+    nextButton.innerHTML = 'Next &raquo;';
+    nextButton.className = 'btn';
+    nextButton.disabled = currentPage === totalPages;
+    nextButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage + 1);
+    paginationContainer.appendChild(nextButton);
+}
+
 
 function deleteReport(id) {
     if (!confirm('Are you sure you want to delete this report?')) {

--- a/reports/silat_1.3.html
+++ b/reports/silat_1.3.html
@@ -43,6 +43,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -9,6 +9,10 @@ function getSurveyDisplayData(survey) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAndDisplayReports('silat_1.3');
+});
+
+function fetchAndDisplayReports(surveyType, page = 1) {
     const tableBody = document.querySelector('#reportsTable tbody');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
@@ -18,7 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.3', {
+    loadingMessage.style.display = 'block';
+    tableBody.innerHTML = '';
+
+    fetch(`/api/reports/${surveyType}?page=${page}`, {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -38,11 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.3 reports found.</td></tr>';
+            tableBody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding: 20px;">No ${surveyType.replace(/_/g, ' ').toUpperCase()} reports found.</td></tr>`;
             return;
         }
-
-        tableBody.innerHTML = ''; // Clear previous content
 
         surveys.forEach(survey => {
             const row = tableBody.insertRow();
@@ -70,14 +75,44 @@ document.addEventListener('DOMContentLoaded', function() {
                 </td>
             `;
         });
+
+        renderPagination(data.pagination, surveyType);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
             loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.3 reports:', error);
+        console.error(`Error fetching ${surveyType} reports:`, error);
     });
-});
+}
+
+function renderPagination(pagination, surveyType) {
+    const { currentPage, totalPages } = pagination;
+    const paginationContainer = document.getElementById('pagination-container');
+    paginationContainer.innerHTML = '';
+
+    if (totalPages <= 1) return;
+
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&laquo; Previous';
+    prevButton.className = 'btn';
+    prevButton.disabled = currentPage === 1;
+    prevButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage - 1);
+    paginationContainer.appendChild(prevButton);
+
+    const pageInfo = document.createElement('span');
+    pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+    pageInfo.style.margin = '0 10px';
+    paginationContainer.appendChild(pageInfo);
+
+    const nextButton = document.createElement('button');
+    nextButton.innerHTML = 'Next &raquo;';
+    nextButton.className = 'btn';
+    nextButton.disabled = currentPage === totalPages;
+    nextButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage + 1);
+    paginationContainer.appendChild(nextButton);
+}
+
 
 function deleteReport(id) {
     if (!confirm('Are you sure you want to delete this report?')) {

--- a/reports/silat_1.4.html
+++ b/reports/silat_1.4.html
@@ -43,6 +43,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -9,6 +9,10 @@ function getSurveyDisplayData(survey) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAndDisplayReports('silat_1.4');
+});
+
+function fetchAndDisplayReports(surveyType, page = 1) {
     const tableBody = document.querySelector('#reportsTable tbody');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
@@ -18,7 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/silat_1.4', {
+    loadingMessage.style.display = 'block';
+    tableBody.innerHTML = '';
+
+    fetch(`/api/reports/${surveyType}?page=${page}`, {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -38,11 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No SILAT_1.4 reports found.</td></tr>';
+            tableBody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding: 20px;">No ${surveyType.replace(/_/g, ' ').toUpperCase()} reports found.</td></tr>`;
             return;
         }
-
-        tableBody.innerHTML = ''; // Clear previous content
 
         surveys.forEach(survey => {
             const row = tableBody.insertRow();
@@ -70,14 +75,44 @@ document.addEventListener('DOMContentLoaded', function() {
                 </td>
             `;
         });
+
+        renderPagination(data.pagination, surveyType);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
             loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching SILAT_1.4 reports:', error);
+        console.error(`Error fetching ${surveyType} reports:`, error);
     });
-});
+}
+
+function renderPagination(pagination, surveyType) {
+    const { currentPage, totalPages } = pagination;
+    const paginationContainer = document.getElementById('pagination-container');
+    paginationContainer.innerHTML = '';
+
+    if (totalPages <= 1) return;
+
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&laquo; Previous';
+    prevButton.className = 'btn';
+    prevButton.disabled = currentPage === 1;
+    prevButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage - 1);
+    paginationContainer.appendChild(prevButton);
+
+    const pageInfo = document.createElement('span');
+    pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+    pageInfo.style.margin = '0 10px';
+    paginationContainer.appendChild(pageInfo);
+
+    const nextButton = document.createElement('button');
+    nextButton.innerHTML = 'Next &raquo;';
+    nextButton.className = 'btn';
+    nextButton.disabled = currentPage === totalPages;
+    nextButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage + 1);
+    paginationContainer.appendChild(nextButton);
+}
+
 
 function deleteReport(id) {
     if (!confirm('Are you sure you want to delete this report?')) {

--- a/reports/tcmats.html
+++ b/reports/tcmats.html
@@ -43,6 +43,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -9,6 +9,10 @@ function getSurveyDisplayData(survey) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAndDisplayReports('tcmats');
+});
+
+function fetchAndDisplayReports(surveyType, page = 1) {
     const tableBody = document.querySelector('#reportsTable tbody');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
@@ -18,7 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/tcmats', {
+    loadingMessage.style.display = 'block';
+    tableBody.innerHTML = '';
+
+    fetch(`/api/reports/${surveyType}?page=${page}`, {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -38,11 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No TCMATS reports found.</td></tr>';
+            tableBody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding: 20px;">No ${surveyType.replace(/_/g, ' ').toUpperCase()} reports found.</td></tr>`;
             return;
         }
-
-        tableBody.innerHTML = ''; // Clear previous content
 
         surveys.forEach(survey => {
             const row = tableBody.insertRow();
@@ -70,14 +75,44 @@ document.addEventListener('DOMContentLoaded', function() {
                 </td>
             `;
         });
+
+        renderPagination(data.pagination, surveyType);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
             loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching TCMATS reports:', error);
+        console.error(`Error fetching ${surveyType} reports:`, error);
     });
-});
+}
+
+function renderPagination(pagination, surveyType) {
+    const { currentPage, totalPages } = pagination;
+    const paginationContainer = document.getElementById('pagination-container');
+    paginationContainer.innerHTML = '';
+
+    if (totalPages <= 1) return;
+
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&laquo; Previous';
+    prevButton.className = 'btn';
+    prevButton.disabled = currentPage === 1;
+    prevButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage - 1);
+    paginationContainer.appendChild(prevButton);
+
+    const pageInfo = document.createElement('span');
+    pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+    pageInfo.style.margin = '0 10px';
+    paginationContainer.appendChild(pageInfo);
+
+    const nextButton = document.createElement('button');
+    nextButton.innerHTML = 'Next &raquo;';
+    nextButton.className = 'btn';
+    nextButton.disabled = currentPage === totalPages;
+    nextButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage + 1);
+    paginationContainer.appendChild(nextButton);
+}
+
 
 function deleteReport(id) {
     if (!confirm('Are you sure you want to delete this report?')) {

--- a/reports/voices.html
+++ b/reports/voices.html
@@ -42,6 +42,7 @@
                 </tbody>
             </table>
             <div id="loadingMessage">Loading reports...</div>
+            <div id="pagination-container" class="pagination"></div>
         </div>
     </div>
 

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -8,6 +8,10 @@ function getSurveyDisplayData(survey) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAndDisplayReports('voices');
+});
+
+function fetchAndDisplayReports(surveyType, page = 1) {
     const tableBody = document.querySelector('#reportsTable tbody');
     const loadingMessage = document.getElementById('loadingMessage');
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
@@ -17,7 +21,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    fetch('/api/reports/voices', {
+    loadingMessage.style.display = 'block';
+    tableBody.innerHTML = '';
+
+    fetch(`/api/reports/${surveyType}?page=${page}`, {
         headers: {
             'Authorization': `Bearer ${user.token}`
         }
@@ -37,11 +44,9 @@ document.addEventListener('DOMContentLoaded', function() {
         allSurveys = surveys; // Store data for export functions
         loadingMessage.style.display = 'none';
         if (surveys.length === 0) {
-            tableBody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding: 20px;">No VOICES reports found.</td></tr>';
+            tableBody.innerHTML = `<tr><td colspan="5" style="text-align:center; padding: 20px;">No ${surveyType.replace(/_/g, ' ').toUpperCase()} reports found.</td></tr>`;
             return;
         }
-
-        tableBody.innerHTML = ''; // Clear previous content
 
         surveys.forEach(survey => {
             const row = tableBody.insertRow();
@@ -68,14 +73,44 @@ document.addEventListener('DOMContentLoaded', function() {
                 </td>
             `;
         });
+
+        renderPagination(data.pagination, surveyType);
     })
     .catch(error => {
         if (error.message !== 'Access Denied') {
             loadingMessage.innerHTML = '<strong>Failed to load reports.</strong><br>Please ensure the backend server is running and accessible.';
         }
-        console.error('Error fetching VOICES reports:', error);
+        console.error(`Error fetching ${surveyType} reports:`, error);
     });
-});
+}
+
+function renderPagination(pagination, surveyType) {
+    const { currentPage, totalPages } = pagination;
+    const paginationContainer = document.getElementById('pagination-container');
+    paginationContainer.innerHTML = '';
+
+    if (totalPages <= 1) return;
+
+    const prevButton = document.createElement('button');
+    prevButton.innerHTML = '&laquo; Previous';
+    prevButton.className = 'btn';
+    prevButton.disabled = currentPage === 1;
+    prevButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage - 1);
+    paginationContainer.appendChild(prevButton);
+
+    const pageInfo = document.createElement('span');
+    pageInfo.textContent = ` Page ${currentPage} of ${totalPages} `;
+    pageInfo.style.margin = '0 10px';
+    paginationContainer.appendChild(pageInfo);
+
+    const nextButton = document.createElement('button');
+    nextButton.innerHTML = 'Next &raquo;';
+    nextButton.className = 'btn';
+    nextButton.disabled = currentPage === totalPages;
+    nextButton.onclick = () => fetchAndDisplayReports(surveyType, currentPage + 1);
+    paginationContainer.appendChild(nextButton);
+}
+
 
 function deleteReport(id) {
     if (!confirm('Are you sure you want to delete this report?')) {


### PR DESCRIPTION
The report pages were missing pagination controls, which prevented users from navigating through multiple pages of reports. This change adds pagination controls to all report pages and updates the corresponding JavaScript to handle paginated data from the API.