### PR TITLE
Fix(reports): Ensure exports use complete dataset

### DIFF
--- a/server.js
+++ b/server.js
@@ -462,6 +462,23 @@ app.get('/api/export/excel', protect, async (req, res) => {
   }
 });
 
+// GET endpoint for ALL survey reports by type (for export)
+app.get('/api/reports/:type/all', protect, async (req, res) => {
+  try {
+    const surveyType = req.params.type;
+    const query = { surveyType: surveyType };
+
+    const surveys = await SurveyResponse.find(query)
+      .populate('user', 'username')
+      .sort({ createdAt: -1 });
+
+    res.status(200).json(surveys);
+  } catch (error) {
+    console.error(`Error fetching all ${req.params.type} reports:`, error);
+    res.status(500).json({ message: 'Failed to fetch reports.', error: error.message });
+  }
+});
+
 // GET endpoint for survey reports by type
 app.get('/api/reports/:type', protect, async (req, res) => {
   try {


### PR DESCRIPTION
The export functions on the report pages were previously using a paginated subset of the data, resulting in incomplete exports.

This commit introduces a new, non-paginated API endpoint `/api/reports/:type/all` that fetches the entire dataset for a specific survey type. The client-side `exportToExcel` and `exportToPDF` functions in `reports/generic_template.js` have been updated to use this new endpoint, ensuring that all data is included in the exported files.

Additionally, a bug in the initial data loading logic on the report pages has been fixed. The code now correctly parses the paginated response, allowing the first page of data to be displayed correctly.