### PR TITLE
feat: add lazy loading to images in survey reports

### DIFF
--- a/reports/lori.js
+++ b/reports/lori.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -69,7 +69,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -57,7 +57,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }


### PR DESCRIPTION
This change adds the loading="lazy" attribute to the images in all survey reports. This will improve the performance of the report pages by deferring the loading of off-screen images.