### PR TITLE
Fix export functionality to include all pages

### DIFF
--- a/reports/export_utils.js
+++ b/reports/export_utils.js
@@ -1,0 +1,35 @@
+// Helper function to fetch all survey data for exports
+async function fetchAllSurveyData(surveyType) {
+    const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
+    if (!user || !user.token) {
+        alert('Authentication required. Please log in.');
+        return null;
+    }
+
+    try {
+        const response = await fetch(`/api/reports/${surveyType}/all`, {
+            headers: { 'Authorization': `Bearer ${user.token}` }
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        return data; // Assuming the endpoint returns the array of surveys directly
+    } catch (error) {
+        console.error(`Error fetching all ${surveyType} survey data for export:`, error);
+        alert('Failed to fetch data for export. Please try again.');
+        return null;
+    }
+}
+
+function flattenObject(obj, prefix = '') {
+    return Object.keys(obj).reduce((acc, k) => {
+        const pre = prefix.length ? prefix + '_' : '';
+        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
+            Object.assign(acc, flattenObject(obj[k], pre + k));
+        } else {
+            acc[pre + k] = obj[k];
+        }
+        return acc;
+    }, {});
+}

--- a/reports/lori.html
+++ b/reports/lori.html
@@ -57,6 +57,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="lori.js"></script>
 </body>
 </html>

--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -57,6 +57,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="silat_1.1.js"></script>
 </body>
 </html>

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -228,44 +228,39 @@ window.onclick = function(event) {
     }
 }
 
-function exportToPDF() {
-    if (allSurveys.length === 0) {
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('silat_1.1');
+    if (!surveys || surveys.length === 0) {
         alert("No data to export.");
         return;
     }
+
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
+    doc.text("SILAT 1.1 Survey Reports", 14, 16);
 
-    doc.text("SILAT_1.1 Survey Reports", 14, 16);
+    const tableBody = surveys.map(survey => {
+        const { schoolDisplay, respondentName } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, schoolDisplay, respondentName, new Date(survey.createdAt).toLocaleString()];
+    });
 
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
+    doc.autoTable({
+        head: [['Username', 'School', 'Respondent', 'Submission Date']],
+        body: tableBody,
+    });
 
     doc.save('silat_1.1-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
+async function exportToExcel() {
+    const allSurveys = await fetchAllSurveyData('silat_1.1');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
 
-    const surveyType = allSurveys.length > 0 ? allSurveys[0].surveyType : 'silat_1.1';
+    const surveyType = 'silat_1.1';
     const labels = surveyLabelMaps[surveyType] || {};
 
     const worksheetData = allSurveys.map(survey => {

--- a/reports/silat_1.2.html
+++ b/reports/silat_1.2.html
@@ -57,6 +57,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="silat_1.2.js"></script>
 </body>
 </html>

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -221,44 +221,39 @@ window.onclick = function(event) {
     }
 }
 
-function exportToPDF() {
-    if (allSurveys.length === 0) {
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('silat_1.2');
+    if (!surveys || surveys.length === 0) {
         alert("No data to export.");
         return;
     }
+
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
+    doc.text("SILAT 1.2 Survey Reports", 14, 16);
 
-    doc.text("SILAT_1.2 Survey Reports", 14, 16);
+    const tableBody = surveys.map(survey => {
+        const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, `${schoolName} (${lga})`, respondentName, new Date(survey.createdAt).toLocaleString()];
+    });
 
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
+    doc.autoTable({
+        head: [['Username', 'School (LGA)', 'Respondent', 'Submission Date']],
+        body: tableBody,
+    });
 
     doc.save('silat_1.2-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
+async function exportToExcel() {
+    const allSurveys = await fetchAllSurveyData('silat_1.2');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
 
-    const surveyType = allSurveys.length > 0 ? allSurveys[0].surveyType : 'silat_1.2';
+    const surveyType = 'silat_1.2';
     const labels = surveyLabelMaps[surveyType] || {};
 
     const worksheetData = allSurveys.map(survey => {

--- a/reports/silat_1.3.html
+++ b/reports/silat_1.3.html
@@ -57,6 +57,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="silat_1.3.js"></script>
 </body>
 </html>

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -221,39 +221,34 @@ window.onclick = function(event) {
     }
 }
 
-function exportToPDF() {
-    if (allSurveys.length === 0) {
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('silat_1.3');
+    if (!surveys || surveys.length === 0) {
         alert("No data to export.");
         return;
     }
+
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
+    doc.text("SILAT 1.3 Survey Reports", 14, 16);
 
-    doc.text("SILAT_1.3 Survey Reports", 14, 16);
+    const tableBody = surveys.map(survey => {
+        const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, `${schoolName} (${lga})`, respondentName, new Date(survey.createdAt).toLocaleString()];
+    });
 
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
+    doc.autoTable({
+        head: [['Username', 'School (LGA)', 'Respondent', 'Submission Date']],
+        body: tableBody,
+    });
 
     doc.save('silat_1.3-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
+async function exportToExcel() {
+    const allSurveys = await fetchAllSurveyData('silat_1.3');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }

--- a/reports/silat_1.4.html
+++ b/reports/silat_1.4.html
@@ -57,6 +57,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="silat_1.4.js"></script>
 </body>
 </html>

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -221,44 +221,39 @@ window.onclick = function(event) {
     }
 }
 
-function exportToPDF() {
-    if (allSurveys.length === 0) {
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('silat_1.4');
+    if (!surveys || surveys.length === 0) {
         alert("No data to export.");
         return;
     }
+
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
+    doc.text("SILAT 1.4 Survey Reports", 14, 16);
 
-    doc.text("SILAT_1.4 Survey Reports", 14, 16);
+    const tableBody = surveys.map(survey => {
+        const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, `${schoolName} (${lga})`, respondentName, new Date(survey.createdAt).toLocaleString()];
+    });
 
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
-
-    doc.autoTable({ html: tableClone });
+    doc.autoTable({
+        head: [['Username', 'School (LGA)', 'Respondent', 'Submission Date']],
+        body: tableBody,
+    });
 
     doc.save('silat_1.4-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
+async function exportToExcel() {
+    const allSurveys = await fetchAllSurveyData('silat_1.4');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
 
-    const surveyType = allSurveys.length > 0 ? allSurveys[0].surveyType : 'silat_1.4';
+    const surveyType = 'silat_1.4';
     const labels = surveyLabelMaps[surveyType] || {};
 
     const worksheetData = allSurveys.map(survey => {

--- a/reports/tcmats.html
+++ b/reports/tcmats.html
@@ -57,6 +57,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="tcmats.js"></script>
 </body>
 </html>

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -217,44 +217,39 @@ window.onclick = function(event) {
     }
 }
 
-function exportToPDF() {
-    if (allSurveys.length === 0) {
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('tcmats');
+    if (!surveys || surveys.length === 0) {
         alert("No data to export.");
         return;
     }
+
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-
     doc.text("TCMATS Survey Reports", 14, 16);
 
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
+    const tableBody = surveys.map(survey => {
+        const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, `${schoolName} (${lga})`, respondentName, new Date(survey.createdAt).toLocaleString()];
+    });
 
-    doc.autoTable({ html: tableClone });
+    doc.autoTable({
+        head: [['Username', 'School (LGA)', 'Respondent', 'Submission Date']],
+        body: tableBody,
+    });
 
     doc.save('tcmats-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToExcel() {
-    if (allSurveys.length === 0) {
+async function exportToExcel() {
+    const allSurveys = await fetchAllSurveyData('tcmats');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
 
-    const surveyType = allSurveys.length > 0 ? allSurveys[0].surveyType : 'tcmats';
+    const surveyType = 'tcmats';
     const labels = surveyLabelMaps[surveyType] || {};
 
     const worksheetData = allSurveys.map(survey => {

--- a/reports/voices.html
+++ b/reports/voices.html
@@ -56,6 +56,7 @@
     </div>
 
     <script src="label_maps.js"></script>
+    <script src="export_utils.js"></script>
     <script src="voices.js"></script>
 </body>
 </html>

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -219,39 +219,34 @@ window.onclick = function(event) {
     }
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
-function exportToPDF() {
-    if (allSurveys.length === 0) {
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('voices');
+    if (!surveys || surveys.length === 0) {
         alert("No data to export.");
         return;
     }
+
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-
     doc.text("VOICES Survey Reports", 14, 16);
 
-    const table = document.getElementById('reportsTable');
-    const tableClone = table.cloneNode(true);
-    Array.from(tableClone.rows).forEach(row => row.deleteCell(-1)); // Remove "Actions" column
+    const tableBody = surveys.map(survey => {
+        const { schoolName, lga } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, `${schoolName} (${lga})`, new Date(survey.createdAt).toLocaleString()];
+    });
 
-    doc.autoTable({ html: tableClone });
+    doc.autoTable({
+        head: [['Username', 'School (LGA)', 'Submission Date']],
+        body: tableBody,
+    });
 
     doc.save('voices-survey-reports.pdf');
 }
 
-function exportToExcel() {
-    if (allSurveys.length === 0) {
+async function exportToExcel() {
+    const allSurveys = await fetchAllSurveyData('voices');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }


### PR DESCRIPTION
The "export to PDF" and "export to Excel" functionalities were only exporting the current page of a report after pagination was implemented.

This was because the export functions were using the paginated data from the frontend.

This commit refactors the export functionality to fetch all data from a dedicated API endpoint before generating the export. This ensures that the entire dataset is included, not just the current page.

A shared `export_utils.js` file was created to hold the common export helper functions (`fetchAllSurveyData` and `flattenObject`) to avoid code duplication. The report-specific HTML and Javascript files were updated to use this shared file.