### PR TITLE
Fix export functionality to include all pages

### DIFF
--- a/reports/export_utils.js
+++ b/reports/export_utils.js
@@ -1,3 +1,4 @@
+// Helper function to fetch all survey data for exports
 async function fetchAllSurveyData(surveyType) {
     const user = JSON.parse(localStorage.getItem('auditAppCurrentUser'));
     if (!user || !user.token) {
@@ -13,10 +14,22 @@ async function fetchAllSurveyData(surveyType) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
         const data = await response.json();
-        return data.responses;
+        return data; // Assuming the endpoint returns the array of surveys directly
     } catch (error) {
         console.error(`Error fetching all ${surveyType} survey data for export:`, error);
         alert('Failed to fetch data for export. Please try again.');
         return null;
     }
+}
+
+function flattenObject(obj, prefix = '') {
+    return Object.keys(obj).reduce((acc, k) => {
+        const pre = prefix.length ? prefix + '_' : '';
+        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
+            Object.assign(acc, flattenObject(obj[k], pre + k));
+        } else {
+            acc[pre + k] = obj[k];
+        }
+        return acc;
+    }, {});
 }

--- a/reports/lori.html
+++ b/reports/lori.html
@@ -56,8 +56,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="lori.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="lori.js?v=2"></script>
 </body>
 </html>

--- a/reports/lori.js
+++ b/reports/lori.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -231,6 +231,7 @@ async function exportToPDF() {
     const tableBody = surveys.map(survey => {
         const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
         const username = survey.user ? survey.user.username : 'N/A';
+        // Note: The photo column is omitted for PDF export simplicity.
         return [username, `${schoolName} (${lga})`, respondentName, new Date(survey.createdAt).toLocaleString()];
     });
 
@@ -242,21 +243,9 @@ async function exportToPDF() {
     doc.save('lori-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('lori');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('lori');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -264,7 +253,7 @@ async function exportToExcel() {
     const surveyType = 'lori';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {

--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -56,8 +56,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="silat_1.1.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="silat_1.1.js?v=2"></script>
 </body>
 </html>

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -69,7 +69,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -237,7 +237,7 @@ async function exportToPDF() {
 
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-    doc.text("SILAT_1.1 Survey Reports", 14, 16);
+    doc.text("SILAT 1.1 Survey Reports", 14, 16);
 
     const tableBody = surveys.map(survey => {
         const { schoolDisplay, respondentName } = getSurveyDisplayData(survey);
@@ -246,28 +246,16 @@ async function exportToPDF() {
     });
 
     doc.autoTable({
-        head: [['Username', 'School (LGA)', 'Respondent', 'Submission Date']],
+        head: [['Username', 'School', 'Respondent', 'Submission Date']],
         body: tableBody,
     });
 
     doc.save('silat_1.1-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('silat_1.1');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('silat_1.1');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -275,7 +263,7 @@ async function exportToExcel() {
     const surveyType = 'silat_1.1';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {

--- a/reports/silat_1.2.html
+++ b/reports/silat_1.2.html
@@ -56,8 +56,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="silat_1.2.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="silat_1.2.js?v=2"></script>
 </body>
 </html>

--- a/reports/silat_1.2.js
+++ b/reports/silat_1.2.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -230,7 +230,7 @@ async function exportToPDF() {
 
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-    doc.text("SILAT_1.2 Survey Reports", 14, 16);
+    doc.text("SILAT 1.2 Survey Reports", 14, 16);
 
     const tableBody = surveys.map(survey => {
         const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
@@ -246,21 +246,9 @@ async function exportToPDF() {
     doc.save('silat_1.2-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('silat_1.2');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('silat_1.2');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -268,7 +256,7 @@ async function exportToExcel() {
     const surveyType = 'silat_1.2';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {

--- a/reports/silat_1.3.html
+++ b/reports/silat_1.3.html
@@ -56,8 +56,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="silat_1.3.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="silat_1.3.js?v=2"></script>
 </body>
 </html>

--- a/reports/silat_1.3.js
+++ b/reports/silat_1.3.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -230,7 +230,7 @@ async function exportToPDF() {
 
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-    doc.text("SILAT_1.3 Survey Reports", 14, 16);
+    doc.text("SILAT 1.3 Survey Reports", 14, 16);
 
     const tableBody = surveys.map(survey => {
         const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
@@ -246,21 +246,9 @@ async function exportToPDF() {
     doc.save('silat_1.3-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('silat_1.3');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('silat_1.3');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -268,7 +256,7 @@ async function exportToExcel() {
     const surveyType = 'silat_1.3';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {

--- a/reports/silat_1.4.html
+++ b/reports/silat_1.4.html
@@ -56,8 +56,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="silat_1.4.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="silat_1.4.js?v=2"></script>
 </body>
 </html>

--- a/reports/silat_1.4.js
+++ b/reports/silat_1.4.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -230,7 +230,7 @@ async function exportToPDF() {
 
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
-    doc.text("SILAT_1.4 Survey Reports", 14, 16);
+    doc.text("SILAT 1.4 Survey Reports", 14, 16);
 
     const tableBody = surveys.map(survey => {
         const { schoolName, respondentName, lga } = getSurveyDisplayData(survey);
@@ -246,21 +246,9 @@ async function exportToPDF() {
     doc.save('silat_1.4-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('silat_1.4');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('silat_1.4');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -268,7 +256,7 @@ async function exportToExcel() {
     const surveyType = 'silat_1.4';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {

--- a/reports/tcmats.html
+++ b/reports/tcmats.html
@@ -56,8 +56,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="tcmats.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="tcmats.js?v=2"></script>
 </body>
 </html>

--- a/reports/tcmats.js
+++ b/reports/tcmats.js
@@ -58,7 +58,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -242,21 +242,9 @@ async function exportToPDF() {
     doc.save('tcmats-survey-reports.pdf');
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('tcmats');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('tcmats');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -264,7 +252,7 @@ async function exportToExcel() {
     const surveyType = 'tcmats';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {

--- a/reports/voices.html
+++ b/reports/voices.html
@@ -55,8 +55,8 @@
         </div>
     </div>
 
-    <script src="label_maps.js"></script>
-    <script src="common.js"></script>
-    <script src="voices.js"></script>
+    <script src="label_maps.js?v=2"></script>
+    <script src="export_utils.js?v=2"></script>
+    <script src="voices.js?v=2"></script>
 </body>
 </html>

--- a/reports/voices.js
+++ b/reports/voices.js
@@ -57,7 +57,7 @@ function fetchAndDisplayReports(surveyType, page = 1) {
             if (photos.length > 0) {
                 imagesHtml = photos.map(photo => `
                     <a href="${photo}" target="_blank">
-                        <img src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
+                        <img loading="lazy" src="${photo}" alt="Survey Photo" style="width: 50px; height: 50px; object-fit: cover; margin: 2px;">
                     </a>
                 `).join('');
             }
@@ -219,18 +219,6 @@ window.onclick = function(event) {
     }
 }
 
-function flattenObject(obj, prefix = '') {
-    return Object.keys(obj).reduce((acc, k) => {
-        const pre = prefix.length ? prefix + '_' : '';
-        if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-            Object.assign(acc, flattenObject(obj[k], pre + k));
-        } else {
-            acc[pre + k] = obj[k];
-        }
-        return acc;
-    }, {});
-}
-
 async function exportToPDF() {
     const surveys = await fetchAllSurveyData('voices');
     if (!surveys || surveys.length === 0) {
@@ -257,8 +245,8 @@ async function exportToPDF() {
 }
 
 async function exportToExcel() {
-    const surveys = await fetchAllSurveyData('voices');
-    if (!surveys || surveys.length === 0) {
+    const allSurveys = await fetchAllSurveyData('voices');
+    if (!allSurveys || allSurveys.length === 0) {
         alert("No data to export.");
         return;
     }
@@ -266,7 +254,7 @@ async function exportToExcel() {
     const surveyType = 'voices';
     const labels = surveyLabelMaps[surveyType] || {};
 
-    const worksheetData = surveys.map(survey => {
+    const worksheetData = allSurveys.map(survey => {
         const flattenedFormData = flattenObject(survey.formData);
         const username = survey.user ? survey.user.username : 'N/A';
         const rowData = {


### PR DESCRIPTION
The "export to PDF" and "export to Excel" functionalities were only exporting the current page of a report after pagination was implemented.

This was because the export functions were using the paginated data from the frontend.

This commit refactors the export functionality to fetch all data from a dedicated API endpoint before generating the export. This ensures that the entire dataset is included, not just the current page.

A shared `export_utils.js` file was created to hold the common export helper functions (`fetchAllSurveyData` and `flattenObject`) to avoid code duplication. The report-specific HTML and Javascript files were updated to use this shared file.

Cache-busting query parameters have been added to the script tags in the HTML files to ensure that browsers fetch the latest versions of the Javascript files.