### PR TITLE
feat: Implement streaming CSV export for SILAT 1.1 reports

### DIFF
--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SILAT_1.1 Survey Reports</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <link rel="stylesheet" href="/reports/style.css">
 </head>
 <body>
@@ -22,8 +19,7 @@
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
                 <h2>SILAT_1.1 Reports</h2>
                 <div id="export-buttons">
-                    <button class="btn" onclick="exportToPDF()">Export to PDF</button>
-                    <button class="btn" onclick="exportToExcel()" style="margin-left: 10px;">Export to Excel</button>
+                    <button class="btn" onclick="exportToCSV()">Export to CSV</button>
                     <button class="btn btn-danger" onclick="deleteAllReports('silat_1.1')" style="margin-left: 10px;">Delete All Reports</button>
                 </div>
             </div>

--- a/verif/silat_1.1_export_test.py
+++ b/verif/silat_1.1_export_test.py
@@ -1,0 +1,110 @@
+import requests
+import os
+import time
+import sys
+import csv
+
+# Add the root directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def get_auth_token(base_url, username, password):
+    """Logs in a user and returns an authentication token."""
+    login_url = f"{base_url}/api/login"
+    credentials = {"username": username, "password": password}
+    try:
+        response = requests.post(login_url, json=credentials)
+        response.raise_for_status()
+        return response.json().get("token")
+    except requests.exceptions.RequestException as e:
+        print(f"Error getting auth token: {e}")
+        return None
+
+def run_export_test():
+    """
+    Tests the SILAT 1.1 CSV export functionality.
+    """
+    print("Starting SILAT 1.1 CSV export test...")
+
+    # --- 1. Setup ---
+    base_url = "http://localhost:3000"
+    admin_username = "admin"
+    admin_password = "AdminPassword1!"
+    test_id = f"silat_1.1_export_test_{int(time.time())}"
+
+    try:
+        # --- 2. Authentication ---
+        print("Getting auth token...")
+        token = get_auth_token(base_url, admin_username, admin_password)
+        if not token:
+            raise Exception("Failed to get authentication token.")
+        print("Successfully obtained auth token.")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # --- 3. Create some test data to ensure the export is not empty ---
+        print("Creating test survey data...")
+        create_url = f"{base_url}/api/surveys/silat_1.1"
+        sample_data = {
+            "formData": {"schoolName": "Export Test School", "localGov": "Epe", "test_id": test_id},
+            "surveyType": "silat_1.1"
+        }
+        create_response = requests.post(create_url, json=sample_data['formData'], headers=headers)
+        create_response.raise_for_status()
+        print("Test data created successfully.")
+
+        # --- 4. Call the export endpoint ---
+        print("Calling the CSV export endpoint...")
+        # The token can also be passed as a query param as designed for browser downloads
+        export_url = f"{base_url}/api/export/silat_1.1/csv?token={token}"
+        export_response = requests.get(export_url, stream=True)
+        export_response.raise_for_status()
+        print("Export endpoint returned success status.")
+
+        # --- 5. Assert response headers ---
+        content_type = export_response.headers.get('Content-Type')
+        if not content_type or 'text/csv' not in content_type:
+            raise Exception(f"Expected Content-Type 'text/csv', but got '{content_type}'")
+        print("Content-Type header is correct.")
+
+        # --- 6. Assert response content ---
+        lines = export_response.text.splitlines()
+        if len(lines) < 2:
+            raise Exception(f"Expected at least 2 lines in CSV (header + data), but got {len(lines)}")
+
+        reader = csv.reader(lines)
+        header = next(reader)
+        if 'test_id' not in header:
+            raise Exception(f"Expected 'test_id' column in CSV header, got {header}")
+
+        found_in_csv = False
+        for row in reader:
+            row_dict = dict(zip(header, row))
+            if row_dict.get('test_id') == test_id:
+                found_in_csv = True
+                break
+
+        if not found_in_csv:
+            raise Exception("Test data not found in the exported CSV.")
+
+        print("Successfully verified test data in the exported CSV.")
+
+        print("\n✅ SILAT 1.1 CSV export test PASSED.")
+
+    except requests.exceptions.RequestException as e:
+        print(f"\n❌ Test FAILED: An error occurred during an HTTP request: {e}")
+        if e.response:
+            print(f"Response body: {e.response.text}")
+    except Exception as e:
+        print(f"\n❌ Test FAILED: An unexpected error occurred: {e}")
+    finally:
+        # Clean up is harder here as we don't have the _id.
+        # We can use the test_id, but need a direct DB connection.
+        # For this test, we'll skip automatic cleanup, but it should be implemented in a real scenario.
+        print("Test finished. Manual cleanup may be required for test data.")
+
+
+if __name__ == "__main__":
+    print("---------------------------------------------------")
+    print("--- Running SILAT 1.1 CSV Export Test ---")
+    print("--- Make sure the backend server is running. ---")
+    print("---------------------------------------------------")
+    run_export_test()

--- a/verif/silat_1.1_report_test.py
+++ b/verif/silat_1.1_report_test.py
@@ -72,10 +72,11 @@ def run_test():
         print("Report fetched successfully.")
 
         # --- 5. Assert response ---
-        reports = report_response.json()
-        if not isinstance(reports, list):
-             raise Exception(f"Expected reports to be a list, but got {type(reports)}")
+        report_data = report_response.json()
+        if not isinstance(report_data.get('responses'), list):
+             raise Exception(f"Expected 'responses' to be a list, but got {type(report_data.get('responses'))}")
 
+        reports = report_data['responses']
         test_report_found = False
         for report in reports:
             if report.get("formData", {}).get("test_id") == test_id:


### PR DESCRIPTION
Replaced the memory-intensive client-side PDF and Excel export with a new server-side streaming CSV export for SILAT 1.1 reports. This resolves the "Failed to fetch data for export" error and high memory consumption when dealing with large datasets.

- Added a new endpoint `/api/export/:surveyType/csv` that uses a MongoDB cursor to stream survey data directly to the client as a CSV file. This keeps server memory usage low.
- The endpoint dynamically generates CSV headers by performing a first pass on the data, ensuring all fields from the flexible `formData` are included.
- Updated the SILAT 1.1 report page to use a single "Export to CSV" button that triggers a download from the new streaming endpoint.
- Removed the old, inefficient `/api/reports/:type/all` endpoint.
- Added a new test script to verify the CSV export functionality.
- Fixed an existing test script that was outdated.