### PR TITLE
Fix SILAT 1.1 PDF export format to match other survey reports

### DIFF
--- a/reports/silat_1.1.html
+++ b/reports/silat_1.1.html
@@ -53,8 +53,8 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/jspdf@latest/dist/jspdf.umd.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
     <script src="label_maps.js?v=2"></script>
     <script src="export_utils.js?v=2"></script>
     <script src="silat_1.1.js?v=2"></script>

--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -240,7 +240,27 @@ function exportToExcel() {
     window.location.href = exportUrl;
 }
 
-function exportToPDF() {
-    console.log("Initiating PDF export for silat_1.1");
-    exportTableToPDF('reportsTable', 'silat_1.1_reports.pdf');
+async function exportToPDF() {
+    const surveys = await fetchAllSurveyData('silat_1.1');
+    if (!surveys || surveys.length === 0) {
+        alert("No data to export.");
+        return;
+    }
+
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text("SILAT 1.1 Survey Reports", 14, 16);
+
+    const tableBody = surveys.map(survey => {
+        const { schoolDisplay, respondentName } = getSurveyDisplayData(survey);
+        const username = survey.user ? survey.user.username : 'N/A';
+        return [username, schoolDisplay, respondentName, new Date(survey.createdAt).toLocaleString()];
+    });
+
+    doc.autoTable({
+        head: [['Username', 'Name of School/Institution / LGEA', 'Respondent Name', 'Submission Date']],
+        body: tableBody,
+    });
+
+    doc.save('silat_1.1_reports.pdf');
 }


### PR DESCRIPTION
The PDF export for the SILAT 1.1 survey report was using html2canvas to take a screenshot of the table, which was inconsistent with the other reports.

This change updates the PDF export functionality for the SILAT 1.1 report to use jsPDF and jsPDF-AutoTable, which is the standard method used by other reports in the application.

The changes include:
- Updating `reports/silat_1.1.html` to include the `jspdf-autotable` library.
- Replacing the `exportToPDF` function in `reports/silat_1.1.js` with a new implementation that fetches all survey data and generates a PDF with a proper table structure.