### PR TITLE
Fix SILAT 1.1 PDF export functionality

### DIFF
--- a/server.js
+++ b/server.js
@@ -1234,6 +1234,20 @@ app.get('/api/export/:surveyType/excel', protect, async (req, res) => {
 });
 
 
+// GET endpoint for ALL survey reports by type (for exporting)
+app.get('/api/reports/:surveyType/all', protect, async (req, res) => {
+  try {
+    const { surveyType } = req.params;
+    const surveys = await SurveyResponse.find({ surveyType })
+      .populate('user', 'username')
+      .sort({ createdAt: -1 });
+    res.status(200).json(surveys);
+  } catch (error) {
+    console.error(`Error fetching all ${req.params.surveyType} reports:`, error);
+    res.status(500).json({ message: 'Failed to fetch all reports for export.', error: error.message });
+  }
+});
+
 // GET endpoint for survey reports by type
 app.get('/api/reports/:type', protect, async (req, res) => {
   try {

--- a/verif/silat_1.1_pdf_export_test.py
+++ b/verif/silat_1.1_pdf_export_test.py
@@ -13,7 +13,15 @@ async def run_pdf_export_test():
         page = await browser.new_page()
 
         try:
-            # Navigate to the reports page
+            # Login first
+            await page.goto("http://localhost:3000")
+            await page.fill("#username", "admin")
+            await page.fill("#password", "AdminPassword1!")
+            await page.click('button:has-text("Login")')
+            await page.wait_for_selector("#landingPage:not(.hidden)", timeout=5000)
+            print("Login successful!")
+
+            # Now, navigate to the reports page
             await page.goto("http://localhost:3000/reports/silat_1.1.html")
 
             # Click the "Export to PDF" button and wait for the download


### PR DESCRIPTION
This change fixes the PDF export for the SILAT 1.1 survey report. The original implementation was broken due to a missing backend endpoint and incorrect client-side logic.

The changes include:
- Adding a new endpoint to `server.js` to fetch all survey data for a specific survey type.
- Updating `reports/silat_1.1.js` to use the new endpoint and generate a PDF with `jsPDF` and `jsPDF-AutoTable`.
- Updating `reports/silat_1.1.html` to include the `jspdf-autotable` library.
- Updating the Playwright test `verif/silat_1.1_pdf_export_test.py` to include authentication, so it can run successfully.