### PR TITLE
Fix(export): Use client-side pagination for PDF export

### DIFF
--- a/server.js
+++ b/server.js
@@ -1234,40 +1234,6 @@ app.get('/api/export/:surveyType/excel', protect, async (req, res) => {
 });
 
 
-// GET endpoint for ALL survey reports by type (for exporting)
-app.get('/api/reports/:surveyType/all', protect, async (req, res) => {
-  try {
-    const { surveyType } = req.params;
-    const surveys = await SurveyResponse.aggregate([
-      { $match: { surveyType: surveyType } },
-      { $sort: { createdAt: -1 } },
-      {
-        $lookup: {
-          from: 'users', // The collection name for the User model
-          localField: 'user',
-          foreignField: '_id',
-          as: 'user'
-        }
-      },
-      {
-        $unwind: {
-          path: '$user',
-          preserveNullAndEmptyArrays: true // Keep surveys even if user is not found
-        }
-      }
-    ]);
-
-    // Mongoose's aggregate returns plain JS objects, not Mongoose documents.
-    // The 'user' field is now an object, so we need to make sure the final
-    // JSON correctly represents this. The structure is already close to what
-    // populate would produce, so we can send it directly.
-    res.status(200).json(surveys);
-  } catch (error) {
-    console.error(`Error fetching all ${req.params.surveyType} reports:`, error);
-    res.status(500).json({ message: 'Failed to fetch all reports for export.', error: error.message });
-  }
-});
-
 // GET endpoint for survey reports by type
 app.get('/api/reports/:type', protect, async (req, res) => {
   try {


### PR DESCRIPTION
This commit fixes the `502 Bad Gateway` error that occurred when exporting large survey reports to PDF. The previous approach of fetching all data in a single request was causing server timeouts.

This change refactors the `fetchAllSurveyData` utility to fetch data in paginated chunks from the existing paginated API endpoint. The client now assembles the complete dataset before generating the PDF. This significantly reduces the load on the server and prevents timeouts.

The changes include:
- Reverting `server.js` to remove the problematic `/all` endpoint.
- Updating `reports/export_utils.js` with a new `fetchAllSurveyData` function that handles paginated fetching.
- Ensuring the `silat_1.1.js` export function works with the new data fetching mechanism.
- Verifying the entire flow with the updated Playwright test.