### PR TITLE
Fix PDF export for SILAT 1.1 survey report

### DIFF
--- a/reports/export_utils.js
+++ b/reports/export_utils.js
@@ -6,47 +6,19 @@ async function fetchAllSurveyData(surveyType) {
     }
 
     try {
-        // First, fetch page 1 to get pagination info
-        const firstPageResponse = await fetch(`/api/reports/${surveyType}?page=1`, {
+        const response = await fetch(`/api/reports/${surveyType}/all`, {
             headers: { 'Authorization': `Bearer ${user.token}` }
         });
 
-        if (!firstPageResponse.ok) {
-            throw new Error(`HTTP error on first page! status: ${firstPageResponse.status}`);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
         }
 
-        const firstPageData = await firstPageResponse.json();
-        const allSurveys = firstPageData.responses;
-        const totalPages = firstPageData.pagination.totalPages;
-
-        // If there's more than one page, fetch the rest
-        if (totalPages > 1) {
-            const pagePromises = [];
-            for (let page = 2; page <= totalPages; page++) {
-                pagePromises.push(
-                    fetch(`/api/reports/${surveyType}?page=${page}`, {
-                        headers: { 'Authorization': `Bearer ${user.token}` }
-                    }).then(res => {
-                        if (!res.ok) {
-                            console.error(`Error fetching page ${page} for ${surveyType}: status ${res.status}`);
-                            return { responses: [] }; // Return empty on error to not break Promise.all
-                        }
-                        return res.json();
-                    })
-                );
-            }
-
-            const remainingPagesData = await Promise.all(pagePromises);
-            remainingPagesData.forEach(pageData => {
-                allSurveys.push(...pageData.responses);
-            });
-        }
-
-        return allSurveys;
+        const surveys = await response.json();
+        return surveys;
 
     } catch (error) {
         console.error(`Error fetching all ${surveyType} survey data for export:`, error);
-        // No alert here to avoid blocking tests
         return null;
     }
 }

--- a/server.js
+++ b/server.js
@@ -1234,6 +1234,20 @@ app.get('/api/export/:surveyType/excel', protect, async (req, res) => {
 });
 
 
+// GET endpoint for ALL survey reports by type (for exports)
+app.get('/api/reports/:type/all', protect, async (req, res) => {
+  try {
+    const surveyType = req.params.type;
+    const surveys = await SurveyResponse.find({ surveyType: surveyType })
+      .populate('user', 'username')
+      .sort({ createdAt: -1 });
+    res.status(200).json(surveys);
+  } catch (error) {
+    console.error(`Error fetching all ${req.params.type} reports:`, error);
+    res.status(500).json({ message: 'Failed to fetch all reports.', error: error.message });
+  }
+});
+
 // GET endpoint for survey reports by type
 app.get('/api/reports/:type', protect, async (req, res) => {
   try {


### PR DESCRIPTION
The PDF export functionality was failing with a "no data to export" error because the client-side logic for fetching paginated data was not working correctly.

This commit fixes the issue by:
1.  Adding a new server-side endpoint `/api/reports/:type/all` that fetches all survey data for a given type at once, without pagination.
2.  Simplifying the client-side `fetchAllSurveyData` function in `reports/export_utils.js` to use this new endpoint.

This makes the PDF export more reliable and consistent with the Excel export functionality.