### PR TITLE
Fix SILAT 1.1 PDF export format to match other survey reports

### DIFF
--- a/reports/silat_1.1.js
+++ b/reports/silat_1.1.js
@@ -258,9 +258,9 @@ async function exportToPDF() {
     });
 
     doc.autoTable({
-        head: [['Username', 'Name of School/Institution / LGEA', 'Respondent Name', 'Submission Date']],
+        head: [['Username', 'School (LGA)', 'Respondent', 'Submission Date']],
         body: tableBody,
     });
 
-    doc.save('silat_1.1_reports.pdf');
+    doc.save('silat_1.1-survey-reports.pdf');
 }


### PR DESCRIPTION
The PDF export for the SILAT 1.1 survey report now follows the same format as the other survey reports. The table headers and filename have been updated to be consistent.