### PR TITLE
feat: Use paginated endpoint for PDF export to fix memory issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -1239,26 +1239,13 @@ app.get('/api/export/:surveyType/excel', protect, async (req, res) => {
 app.get('/api/reports/:type/all', protect, async (req, res) => {
   try {
     const surveyType = req.params.type;
-    res.setHeader('Content-Type', 'application/x-ndjson');
-    res.setHeader('Content-Disposition', `attachment; filename="${surveyType}-all.ndjson"`);
-
-    const cursor = SurveyResponse.find({ surveyType: surveyType })
+    const surveys = await SurveyResponse.find({ surveyType: surveyType })
       .populate('user', 'username')
-      .sort({ createdAt: -1 })
-      .cursor();
-
-    for (let doc = await cursor.next(); doc != null; doc = await cursor.next()) {
-      res.write(JSON.stringify(doc) + '\n');
-    }
-
-    res.end();
+      .sort({ createdAt: -1 });
+    res.status(200).json(surveys);
   } catch (error) {
     console.error(`Error fetching all ${req.params.type} reports:`, error);
-    if (!res.headersSent) {
-      res.status(500).json({ message: 'Failed to fetch all reports.', error: error.message });
-    } else {
-      res.end();
-    }
+    res.status(500).json({ message: 'Failed to fetch all reports.', error: error.message });
   }
 });
 


### PR DESCRIPTION
The PDF export feature was previously using an endpoint (`/api/reports/:type/all`) that fetched all survey data at once. This caused high server memory usage and 502 errors for large reports.

This commit modifies the client-side export utility (`export_utils.js`) to use the existing paginated endpoint (`/api/reports/:type`). The `fetchAllSurveyData` function now fetches data in pages and aggregates it on the client before generating the PDF.

This approach resolves the server-side memory overload by breaking the request into smaller, manageable chunks. The unused and problematic streaming code that was previously added to `server.js` has been removed by restoring the file to its original state.